### PR TITLE
[SVR-10] feat: 회원가입 API 추가

### DIFF
--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	implementation project(":domain:core-domain")
 	implementation project(":domain:auth-domain")
 	implementation project(":domain:user-domain")
+	implementation project(":domain:university-domain")
 	implementation project(":modules:jwt-provider")
 }
 

--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	//spring-data

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/AuthApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/AuthApi.java
@@ -6,6 +6,7 @@ import com.uket.app.ticket.api.dto.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +22,7 @@ public interface AuthApi {
     @Operation(summary = "소셜 로그인", description = "소셜 로그인을 진행합니다.")
     @PostMapping("/login/{provider}")
     ResponseEntity<TokenResponse> login(
+            @Valid
             @RequestBody LoginRequest request,
             @Parameter(example = "kakao", description = "oAuth 제공자 이름")
             @PathVariable("provider") String provider
@@ -29,6 +31,7 @@ public interface AuthApi {
     @Operation(summary = "토큰 재발행", description = "리프레시 토큰으로 새로은 토큰을 발행합니다.")
     @PostMapping(value = "/reissue")
     ResponseEntity<TokenResponse> reissue(
+            @Valid
             @RequestBody TokenReissueRequest request
     );
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
@@ -1,0 +1,38 @@
+package com.uket.app.ticket.api.controller;
+
+import com.uket.app.ticket.api.dto.request.UserRegisterRequest;
+import com.uket.app.ticket.api.dto.response.TokenResponse;
+import com.uket.domain.auth.config.register.IsRegistered;
+import com.uket.domain.auth.config.userid.LoginUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "유저 API", description = "유저 관련 API")
+@RestController
+@SecurityRequirement(name = "JWT")
+@RequestMapping("/api/v1/users")
+public interface UserApi {
+
+    @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
+    @PostMapping("/register/{type}")
+    ResponseEntity<TokenResponse> register(
+            @Parameter(hidden = true)
+            @LoginUserId Long userId,
+
+            @Parameter(hidden = true)
+            @IsRegistered Boolean isRegistered,
+
+            @PathVariable("type") String type,
+
+            @RequestBody UserRegisterRequest request
+    );
+
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,15 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public interface UserApi {
 
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
-    @PostMapping("/register/{type}")
+    @PostMapping("/register")
     ResponseEntity<TokenResponse> register(
             @Parameter(hidden = true)
             @LoginUserId Long userId,
 
             @Parameter(hidden = true)
             @IsRegistered Boolean isRegistered,
-
-            @PathVariable("type") String type,
 
             @RequestBody UserRegisterRequest request
     );

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +30,7 @@ public interface UserApi {
             @Parameter(hidden = true)
             @IsRegistered Boolean isRegistered,
 
+            @Valid
             @RequestBody UserRegisterRequest request
     );
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/AuthController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/AuthController.java
@@ -5,7 +5,7 @@ import com.uket.app.ticket.api.dto.request.LoginRequest;
 import com.uket.app.ticket.api.dto.request.TokenReissueRequest;
 import com.uket.app.ticket.api.dto.response.TokenResponse;
 import com.uket.domain.auth.dto.response.AuthToken;
-import com.uket.domain.auth.service.AuthService;
+import com.uket.app.ticket.api.service.AuthService;
 import com.uket.domain.user.enums.Platform;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
@@ -21,14 +21,14 @@ public class UserController implements UserApi {
     @Override
     public ResponseEntity<TokenResponse> register(Long userId, Boolean isRegistered, UserRegisterRequest request) {
 
-        CreateUserDetailsDto createUserDetailsDto = getCreateUserDetailsDto(request);
+        CreateUserDetailsDto createUserDetailsDto = generateCreateUserDetailsDto(request);
 
-        AuthToken authToken = userRegisterService.register(userId, createUserDetailsDto);
+        AuthToken authToken = userRegisterService.register(userId, createUserDetailsDto, request.university());
         TokenResponse response = TokenResponse.from(authToken);
         return ResponseEntity.ok(response);
     }
 
-    private CreateUserDetailsDto getCreateUserDetailsDto(UserRegisterRequest request) {
+    private CreateUserDetailsDto generateCreateUserDetailsDto(UserRegisterRequest request) {
         return CreateUserDetailsDto.builder()
                 .depositorName(request.depositorName())
                 .phoneNumber(request.phoneNumber())

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
@@ -1,0 +1,23 @@
+package com.uket.app.ticket.api.controller.impl;
+
+import com.uket.app.ticket.api.controller.UserApi;
+import com.uket.app.ticket.api.dto.request.UserRegisterRequest;
+import com.uket.app.ticket.api.dto.response.TokenResponse;
+import com.uket.domain.auth.dto.response.AuthToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    @Override
+    public ResponseEntity<TokenResponse> register(Long userId, Boolean isRegistered, String type, UserRegisterRequest request) {
+
+        TokenResponse response = TokenResponse.from(AuthToken.of(null,null,true));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
@@ -3,7 +3,9 @@ package com.uket.app.ticket.api.controller.impl;
 import com.uket.app.ticket.api.controller.UserApi;
 import com.uket.app.ticket.api.dto.request.UserRegisterRequest;
 import com.uket.app.ticket.api.dto.response.TokenResponse;
+import com.uket.app.ticket.api.service.UserRegisterService;
 import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.user.dto.CreateUserDetailsDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,10 +16,24 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class UserController implements UserApi {
 
-    @Override
-    public ResponseEntity<TokenResponse> register(Long userId, Boolean isRegistered, String type, UserRegisterRequest request) {
+    private final UserRegisterService userRegisterService;
 
-        TokenResponse response = TokenResponse.from(AuthToken.of(null,null,true));
+    @Override
+    public ResponseEntity<TokenResponse> register(Long userId, Boolean isRegistered, UserRegisterRequest request) {
+
+        CreateUserDetailsDto createUserDetailsDto = getCreateUserDetailsDto(request);
+
+        AuthToken authToken = userRegisterService.register(userId, createUserDetailsDto);
+        TokenResponse response = TokenResponse.from(authToken);
         return ResponseEntity.ok(response);
+    }
+
+    private CreateUserDetailsDto getCreateUserDetailsDto(UserRegisterRequest request) {
+        return CreateUserDetailsDto.builder()
+                .depositorName(request.depositorName())
+                .phoneNumber(request.phoneNumber())
+                .studentMajor(request.studentMajor())
+                .studentCode(request.studentCode())
+                .build();
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/LoginRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/LoginRequest.java
@@ -1,11 +1,14 @@
 package com.uket.app.ticket.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record LoginRequest(
         @Schema(description = "인가 코드", example = "C95mSFwbWNVWUA1OCQ9mLSYFU5Dj7b5sFTgsy5lUNAAABjwtYyp")
+        @NotNull(message = "code 는 null 일 수 없습니다.")
         String code,
         @Schema(description = "Redirect URI", example = "http://localhost:8080/login/oauth2/code/kakao")
+        @NotNull(message = "redirectUri 은 null 일 수 없습니다.")
         String redirectUri
 ) {
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/TokenReissueRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/TokenReissueRequest.java
@@ -1,7 +1,11 @@
 package com.uket.app.ticket.api.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record TokenReissueRequest(
+        @NotNull(message = "accessToken 은 null 일 수 없습니다.")
         String accessToken,
+        @NotNull(message = "refreshToken 은 null 일 수 없습니다.")
         String refreshToken
 ) {
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -1,0 +1,7 @@
+package com.uket.app.ticket.api.dto.request;
+
+public record UserRegisterRequest(
+
+) {
+
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -1,11 +1,14 @@
 package com.uket.app.ticket.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record UserRegisterRequest(
         @Schema(description = "입금자명", example = "홍길동")
+        @NotNull(message = "depositorName 은 null 일 수 없습니다.")
         String depositorName,
         @Schema(description = "전화번호", example = "01012341234")
+        @NotNull(message = "phoneNumber 는 null 일 수 없습니다.")
         String phoneNumber,
         @Schema(description = "대학 이름", example = "konkuk")
         String university,

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -2,7 +2,9 @@ package com.uket.app.ticket.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record UserRegisterRequest(
         @Schema(description = "입금자명", example = "홍길동")
         @NotNull(message = "depositorName 은 null 일 수 없습니다.")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -10,7 +10,7 @@ public record UserRegisterRequest(
         @Schema(description = "전화번호", example = "01012341234")
         @NotNull(message = "phoneNumber 는 null 일 수 없습니다.")
         String phoneNumber,
-        @Schema(description = "대학 이름", example = "konkuk")
+        @Schema(description = "대학 이름", example = "건국대학교")
         String university,
         @Schema(description = "학과", example = "컴퓨터공학부")
         String studentMajor,

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -1,10 +1,17 @@
 package com.uket.app.ticket.api.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserRegisterRequest(
+        @Schema(description = "입금자명", example = "홍길동")
         String depositorName,
+        @Schema(description = "전화번호", example = "01012341234")
         String phoneNumber,
+        @Schema(description = "대학 이름", example = "konkuk")
         String university,
+        @Schema(description = "학과", example = "컴퓨터공학부")
         String studentMajor,
+        @Schema(description = "학번", example = "202412345")
         String studentCode
 ) {
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
@@ -1,0 +1,31 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.app.ticket.api.util.AuthTokenGenerator;
+import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.user.dto.CreateUserDetailsDto;
+import com.uket.domain.user.entity.UserDetails;
+import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.service.UserDetailsService;
+import com.uket.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserRegisterService {
+
+    private final UserService userService;
+    private final UserDetailsService userDetailsService;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    @Transactional
+    public AuthToken register(Long userId, CreateUserDetailsDto createUserDetailsDto) {
+        Users findUser = userService.findById(userId);
+        UserDetails userDetails = userDetailsService.saveUserDetails(createUserDetailsDto);
+
+        findUser.register(userDetails);
+        return authTokenGenerator.generateAuthToken(findUser);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
@@ -2,11 +2,14 @@ package com.uket.app.ticket.api.service;
 
 import com.uket.app.ticket.api.util.AuthTokenGenerator;
 import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.service.UniversityService;
 import com.uket.domain.user.dto.CreateUserDetailsDto;
 import com.uket.domain.user.entity.UserDetails;
 import com.uket.domain.user.entity.Users;
 import com.uket.domain.user.service.UserDetailsService;
 import com.uket.domain.user.service.UserService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,15 +20,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserRegisterService {
 
     private final UserService userService;
+    private final UniversityService universityService;
     private final UserDetailsService userDetailsService;
     private final AuthTokenGenerator authTokenGenerator;
 
     @Transactional
-    public AuthToken register(Long userId, CreateUserDetailsDto createUserDetailsDto) {
+    public AuthToken register(Long userId, CreateUserDetailsDto createUserDetailsDto, String university) {
         Users findUser = userService.findById(userId);
-        UserDetails userDetails = userDetailsService.saveUserDetails(createUserDetailsDto);
 
-        findUser.register(userDetails);
+        UserDetails userDetails = userDetailsService.saveUserDetails(createUserDetailsDto);
+        Optional<University> findUniversity = universityService.findByName(university);
+
+        findUser.register(userDetails, findUniversity.orElse(universityService.getDefault()));
         return authTokenGenerator.generateAuthToken(findUser);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/AuthTokenGenerator.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/AuthTokenGenerator.java
@@ -1,0 +1,38 @@
+package com.uket.app.ticket.api.util;
+
+import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.user.dto.UserDto;
+import com.uket.domain.user.entity.Users;
+import com.uket.modules.jwt.auth.JwtAuthTokenUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokenGenerator {
+
+    private final JwtAuthTokenUtil jwtAuthTokenUtil;
+
+    public AuthToken generateAuthToken(Users user) {
+        UserDto userDto = generateUserDto(user);
+
+        Long userId = userDto.userId();
+        String name = userDto.name();
+        String role = userDto.role();
+        Boolean isRegistered = userDto.isRegistered();
+
+        String newAccessToken = jwtAuthTokenUtil.createAccessToken(userId, name, role, isRegistered);
+        String newRefreshToken = jwtAuthTokenUtil.createRefreshToken(userId);
+
+        return AuthToken.of(newAccessToken, newRefreshToken, isRegistered);
+    }
+
+    private UserDto generateUserDto(Users user) {
+        return UserDto.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .role(String.valueOf(user.getRole()))
+                .isRegistered(user.getIsRegistered())
+                .build();
+    }
+}

--- a/application/ticket-app-api/src/main/resources/application.yml
+++ b/application/ticket-app-api/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
           batch_size: 100
         order_inserts: true
         order_updates: true
+        default_batch_fetch_size: 100
 
 springdoc:
   packages-to-scan: com.uket

--- a/application/ticket-app-api/src/main/resources/application.yml
+++ b/application/ticket-app-api/src/main/resources/application.yml
@@ -40,6 +40,9 @@ spring:
   config:
     activate:
       on-profile: local
+  sql:
+    init:
+      mode: always
   data:
     redis:
       host: localhost
@@ -50,6 +53,7 @@ spring:
     username: ${DEV_MYSQL_USERNAME}
     password: ${DEV_MYSQL_PASSWORD}
   jpa:
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: create
     properties:

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+insert into university (name) values ('외부인'),('건국대학교');

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
@@ -1,0 +1,114 @@
+package com.uket.app.ticket.api.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uket.app.ticket.api.dto.request.UserRegisterRequest;
+import com.uket.app.ticket.api.dto.response.TokenResponse;
+import com.uket.app.ticket.api.util.AuthTokenGenerator;
+import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.repository.UniversityRepository;
+import com.uket.domain.user.dto.CreateUserDto;
+import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.enums.Platform;
+import com.uket.domain.user.enums.UserRole;
+import com.uket.domain.user.service.UserService;
+import com.uket.modules.jwt.auth.JwtAuthTokenUtil;
+import com.uket.modules.jwt.auth.constants.JwtValues;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    private static final String BASE_URL = "/api/v1/users";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UniversityRepository universityRepository;
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+    @Autowired
+    private JwtAuthTokenUtil jwtAuthTokenUtil;
+
+    private Users user;
+
+    @BeforeEach
+    void beforeEach() {
+        CreateUserDto createUserDto = CreateUserDto.builder()
+                .name("test")
+                .role(UserRole.ROLE_USER)
+                .platform(Platform.KAKAO)
+                .platformId("1234")
+                .email("abc@naver.com")
+                .build();
+
+        user = userService.saveUser(createUserDto);
+
+        universityRepository.save(University.builder().name("외부인").build());
+        universityRepository.save(University.builder().name("건국대학교").build());
+    }
+
+    @Test
+    void 회원가입시_토큰이_재발급된다() throws Exception {
+
+        UserRegisterRequest request = new UserRegisterRequest("홍길동",
+                "01012341234", "건국대학교", "컴퓨터공학부", "12341234");
+        AuthToken authToken = authTokenGenerator.generateAuthToken(user);
+        String accessToken = String.join("", JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX, authToken.accessToken());
+
+        ResultActions perform = mockMvc.perform(
+                post(BASE_URL + "/register")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.isRegistered").value(true));
+    }
+
+
+    @Test
+    void 재발급된_토큰은_회원가입된_상태여야_한다() throws Exception {
+
+        UserRegisterRequest request = new UserRegisterRequest("홍길동",
+                "01012341234", "건국대학교", "컴퓨터공학부", "12341234");
+        AuthToken authToken = authTokenGenerator.generateAuthToken(user);
+        String accessToken = String.join("", JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX, authToken.accessToken());
+
+        ResultActions perform = mockMvc.perform(
+                post(BASE_URL + "/register")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String response = perform.andReturn().getResponse().getContentAsString();
+        TokenResponse tokenResponse = objectMapper.readValue(response, TokenResponse.class);
+
+        Assertions.assertThat(jwtAuthTokenUtil.isRegistered(tokenResponse.accessToken())).isTrue();
+    }
+}

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
@@ -1,0 +1,138 @@
+package com.uket.app.ticket.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.repository.UniversityRepository;
+import com.uket.domain.user.dto.CreateUserDetailsDto;
+import com.uket.domain.user.dto.CreateUserDto;
+import com.uket.domain.user.entity.UserDetails;
+import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.enums.Platform;
+import com.uket.domain.user.enums.UserRole;
+import com.uket.domain.user.service.UserService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+class UserRegisterServiceTest {
+
+    private static final String UNIVERSITY_OUTSIDER = "외부인";
+    private static final String UNIVERSITY_KONKUK = "건국대학교";
+
+    @Autowired
+    UserRegisterService userRegisterService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UniversityRepository universityRepository;
+
+    private Users user;
+
+    @BeforeEach
+    void beforeEach() {
+        CreateUserDto createUserDto = CreateUserDto.builder()
+                .name("test")
+                .role(UserRole.ROLE_USER)
+                .platform(Platform.KAKAO)
+                .platformId("1234")
+                .email("abc@naver.com")
+                .build();
+
+        user = userService.saveUser(createUserDto);
+
+        universityRepository.save(University.builder().name(UNIVERSITY_OUTSIDER).build());
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).build());
+    }
+
+    @Test
+    void 회원가입시_토큰을_반환한다() {
+
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터 공학부")
+                .studentCode("1234")
+                .build();
+
+        AuthToken authToken = userRegisterService.register(user.getId(), createUserDetailsDto, null);
+
+        assertThat(authToken.accessToken()).isNotNull();
+        assertThat(authToken.refreshToken()).isNotNull();
+        assertThat(authToken.isRegistered()).isTrue();
+    }
+
+    @Test
+    void 대학을_입력하지_않을_시_외부인으로_처리된다() {
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터 공학부")
+                .studentCode("1234")
+                .build();
+
+        userRegisterService.register(user.getId(), createUserDetailsDto, UNIVERSITY_KONKUK);
+        Users findUser = userService.findById(user.getId());
+
+        assertThat(findUser.getUniversity().getName()).isEqualTo(UNIVERSITY_KONKUK);
+    }
+
+    @Test
+    void 대학을_입력할_시_해당_대학으로_처리된다() {
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터 공학부")
+                .studentCode("1234")
+                .build();
+
+        userRegisterService.register(user.getId(), createUserDetailsDto, null);
+        Users findUser = userService.findById(user.getId());
+
+        assertThat(findUser.getUniversity().getName()).isEqualTo(UNIVERSITY_OUTSIDER);
+    }
+
+    @Test
+    void 회원가입이_완료되면_회원의_가입여부가_true가_된다() {
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터 공학부")
+                .studentCode("1234")
+                .build();
+
+        userRegisterService.register(user.getId(), createUserDetailsDto, null);
+        Users findUser = userService.findById(user.getId());
+
+        assertThat(findUser.getIsRegistered()).isTrue();
+    }
+
+    @Test
+    void 회원가입이_완료되면_회원의_세부정보가_저장된다() {
+        String depositorName = "홍길동";
+        String phoneNumber = "01012341234";
+        String major = "컴퓨터 공학부";
+        String code = "1234";
+
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName(depositorName)
+                .phoneNumber(phoneNumber)
+                .studentMajor(major)
+                .studentCode(code)
+                .build();
+
+        userRegisterService.register(user.getId(), createUserDetailsDto, null);
+        Users findUser = userService.findById(user.getId());
+        UserDetails userDetails = findUser.getUserDetails();
+
+        assertThat(userDetails.getDepositorName()).isEqualTo(depositorName);
+        assertThat(userDetails.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(userDetails.getStudentMajor()).isEqualTo(major);
+        assertThat(userDetails.getStudentCode()).isEqualTo(code);
+    }
+}

--- a/application/ticket-app-api/src/test/resources/application.yml
+++ b/application/ticket-app-api/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  sql:
+    init:
+      mode: never
   jpa:
     hibernate:
       ddl-auto: create

--- a/core/src/main/java/com/uket/core/exception/BaseException.java
+++ b/core/src/main/java/com/uket/core/exception/BaseException.java
@@ -1,10 +1,13 @@
 package com.uket.core.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class BaseException extends RuntimeException{
     private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -32,7 +32,13 @@ public enum ErrorCode {
      * User Errors
      */
     NOT_FOUND_USER(404,"US0001", "해당 사용자를 찾을 수 없습니다."),
-    ALREADY_EXIST_USER(409,"US0002", "이미 가입된 사용자입니다.");
+    ALREADY_EXIST_USER(409,"US0002", "이미 가입된 사용자입니다."),
+
+    /**
+     * University Errors
+     */
+    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다.");
+
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -39,7 +39,6 @@ public enum ErrorCode {
      */
     NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다.");
 
-
     private final int status;
     private final String code;
     private final String message;

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -1,5 +1,6 @@
 package com.uket.domain.auth.config;
 
+import com.uket.domain.auth.config.register.IsRegisteredArgumentResolver;
 import com.uket.domain.auth.config.userid.LoginUserArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,10 +13,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class AuthConfig implements WebMvcConfigurer {
 
     private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final IsRegisteredArgumentResolver isRegisteredArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
+        resolvers.add(isRegisteredArgumentResolver);
         WebMvcConfigurer.super.addArgumentResolvers(resolvers);
     }
 }

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/register/IsRegistered.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/register/IsRegistered.java
@@ -1,0 +1,12 @@
+package com.uket.domain.auth.config.register;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IsRegistered {
+
+}

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/register/IsRegisteredArgumentResolver.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/register/IsRegisteredArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.uket.domain.auth.config.register;
+
+import com.uket.modules.jwt.auth.JwtAuthTokenUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IsRegisteredArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtAuthTokenUtil jwtAuthTokenUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(IsRegistered.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken = (String) SecurityContextHolder.getContext().getAuthentication().getCredentials();
+        return jwtAuthTokenUtil.isRegistered(accessToken);
+    }
+}

--- a/domain/university-domain/build.gradle
+++ b/domain/university-domain/build.gradle
@@ -1,0 +1,15 @@
+dependencies {
+    implementation project(":domain:core-domain")
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.named('bootJar') {
+    enabled = false
+}
+
+tasks.named('jar') {
+    enabled = true
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
@@ -1,0 +1,26 @@
+package com.uket.domain.university.entity;
+
+import com.uket.domain.core.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class University extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String logoUrl;
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
@@ -1,10 +1,11 @@
 package com.uket.domain.university.entity;
 
-import com.uket.domain.core.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +16,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"name"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class University extends BaseEntity {
+public class University {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/domain/university-domain/src/main/java/com/uket/domain/university/exception/UniversityException.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/exception/UniversityException.java
@@ -1,0 +1,11 @@
+package com.uket.domain.university.exception;
+
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
+
+public class UniversityException extends BaseException {
+
+    public UniversityException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/repository/UniversityRepository.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/repository/UniversityRepository.java
@@ -1,0 +1,8 @@
+package com.uket.domain.university.repository;
+
+import com.uket.domain.university.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UniversityRepository extends JpaRepository<University, Long> {
+
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/repository/UniversityRepository.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/repository/UniversityRepository.java
@@ -1,8 +1,10 @@
 package com.uket.domain.university.repository;
 
 import com.uket.domain.university.entity.University;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UniversityRepository extends JpaRepository<University, Long> {
 
+    Optional<University> findByName(String name);
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -1,0 +1,12 @@
+package com.uket.domain.university.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UniversityService {
+
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UniversityService {
 
+    private static final String DEFAULT_UNIVERSITY_NAME = "외부인";
+
     private final UniversityRepository universityRepository;
 
     public Optional<University> findByName(String name) {
@@ -21,7 +23,7 @@ public class UniversityService {
     }
 
     public University getDefault(){
-        return universityRepository.findByName("외부인")
+        return universityRepository.findByName(DEFAULT_UNIVERSITY_NAME)
                 .orElseThrow(()-> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
     }
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -1,5 +1,10 @@
 package com.uket.domain.university.service;
 
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.exception.UniversityException;
+import com.uket.domain.university.repository.UniversityRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UniversityService {
 
+    private final UniversityRepository universityRepository;
+
+    public Optional<University> findByName(String name) {
+        return universityRepository.findByName(name);
+    }
+
+    public University getDefault(){
+        return universityRepository.findByName("외부인")
+                .orElseThrow(()-> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
+    }
 }

--- a/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
+++ b/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
@@ -1,0 +1,34 @@
+package com.uket.domain.university.service;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.university.exception.UniversityException;
+import com.uket.domain.university.repository.UniversityRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UniversityServiceTest {
+    @InjectMocks
+    UniversityService universityService;
+
+    @Mock
+    UniversityRepository universityRepository;
+
+    @Test
+    void 기본값이_존재하지_않을_경우_예외를_발생시킨다() {
+        when(universityRepository.findByName(any())).thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> universityService.getDefault())
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage())
+                .isInstanceOf(UniversityException.class);
+    }
+}

--- a/domain/user-domain/build.gradle
+++ b/domain/user-domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(":domain:core-domain")
+    implementation project(":domain:university-domain")
 }
 
 tasks.named('test') {

--- a/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
@@ -1,9 +1,8 @@
-package com.uket.app.ticket.api.dto.request;
+package com.uket.domain.user.dto;
 
-public record UserRegisterRequest(
+public record CreateUserDetailsDto(
         String depositorName,
         String phoneNumber,
-        String university,
         String studentMajor,
         String studentCode
 ) {

--- a/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
@@ -1,5 +1,8 @@
 package com.uket.domain.user.dto;
 
+import lombok.Builder;
+
+@Builder
 public record CreateUserDetailsDto(
         String depositorName,
         String phoneNumber,

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/UserDetails.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/UserDetails.java
@@ -1,0 +1,29 @@
+package com.uket.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_details_id")
+    private Long id;
+    String depositorName;
+    String phoneNumber;
+    String studentMajor;
+    String studentCode;
+}

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
@@ -1,6 +1,7 @@
 package com.uket.domain.user.entity;
 
 import com.uket.domain.core.entity.BaseEntity;
+import com.uket.domain.university.entity.University;
 import com.uket.domain.user.enums.Platform;
 import com.uket.domain.user.enums.UserRole;
 import jakarta.persistence.CascadeType;
@@ -36,6 +37,10 @@ public class Users extends BaseEntity {
     @JoinColumn(name = "user_details_id")
     private UserDetails userDetails;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_id")
+    private University university;
+
     private String name;
     private String email;
     @Enumerated(EnumType.STRING)
@@ -50,8 +55,9 @@ public class Users extends BaseEntity {
         this.name = name;
     }
 
-    public void register(UserDetails userDetails) {
-        this.userDetails = userDetails;
+    public void register(UserDetails userDetails, University university) {
         this.isRegistered = true;
+        this.userDetails = userDetails;
+        this.university = university;
     }
 }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,7 +38,7 @@ public class Users extends BaseEntity {
     @JoinColumn(name = "user_details_id")
     private UserDetails userDetails;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university_id")
     private University university;
 

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
@@ -7,9 +7,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +31,10 @@ public class Users extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_details_id")
+    private UserDetails userDetails;
+
     private String name;
     private String email;
     @Enumerated(EnumType.STRING)
@@ -36,8 +43,6 @@ public class Users extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRole role;
     private Boolean isRegistered;
-
-    private String phoneNumber;
 
     public void updateEmailAndName(String email, String name) {
         this.email = email;

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/Users.java
@@ -3,6 +3,7 @@ package com.uket.domain.user.entity;
 import com.uket.domain.core.entity.BaseEntity;
 import com.uket.domain.user.enums.Platform;
 import com.uket.domain.user.enums.UserRole;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -31,7 +32,7 @@ public class Users extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "user_details_id")
     private UserDetails userDetails;
 
@@ -47,5 +48,10 @@ public class Users extends BaseEntity {
     public void updateEmailAndName(String email, String name) {
         this.email = email;
         this.name = name;
+    }
+
+    public void register(UserDetails userDetails) {
+        this.userDetails = userDetails;
+        this.isRegistered = true;
     }
 }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/repository/UserDetailsRepository.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/repository/UserDetailsRepository.java
@@ -1,0 +1,8 @@
+package com.uket.domain.user.repository;
+
+import com.uket.domain.user.entity.UserDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDetailsRepository extends JpaRepository<UserDetails, Long> {
+
+}

--- a/domain/user-domain/src/main/java/com/uket/domain/user/service/UserDetailsService.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/service/UserDetailsService.java
@@ -1,0 +1,29 @@
+package com.uket.domain.user.service;
+
+import com.uket.domain.user.dto.CreateUserDetailsDto;
+import com.uket.domain.user.entity.UserDetails;
+import com.uket.domain.user.repository.UserDetailsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserDetailsService {
+
+    private final UserDetailsRepository userDetailsRepository;
+
+    @Transactional
+    public UserDetails saveUserDetails(CreateUserDetailsDto createUserDetailsDto) {
+
+        UserDetails userDetails = UserDetails.builder()
+                .depositorName(createUserDetailsDto.depositorName())
+                .phoneNumber(createUserDetailsDto.phoneNumber())
+                .studentMajor(createUserDetailsDto.studentMajor())
+                .studentCode(createUserDetailsDto.studentCode())
+                .build();
+
+        return userDetailsRepository.save(userDetails);
+    }
+}


### PR DESCRIPTION
# 📌 개요
- 회원가입 API 추가했습니다.
  - 회원의 세부 정보를 추가하는 방식으로 구현했습니다.
  - DB에 존재하는 대학을 요청할 경우 해당 대학으로 연결하고 못찾을 경우 외부인으로 설정하도록 했습니다.
- 회원가입 성공 시, `payload`가 `isRegistered: true`로 변경된 `accessToken` 및 `refreshToken`이 재발급됩니다.
- `@IsRegistered` 어노테이션은 `accessToken`으로 부터 회원가입 정보를 추출해서 사용할 수 있는 어노테이션입니다. 
다음과 같이 활용됩니다.
<img width="510" alt="image" src="https://github.com/DCNJ-Uket/Uket-BE/assets/127181370/15e40fb4-6990-442e-ad91-91beef07fbab">


# 💻 작업사항
- [x] 회원가입 로직 추가
- [x] `isRegistered` 값 토큰으로 부터 추출하는 `Interceptor` 추가
- [x] `UserDetails` 테이블 및 부가 기능 추가
- [x] `University` 테이블 및 부가 기능 추가
- [x] `UserController`, `UserRegisterService`, `UniversityService` 관련 테스트 추가

# ❌ 주의사항
- erd가 수정된 부분이 있습니다. 참고해주세요
  - [변경된 ERD](https://www.erdcloud.com/d/WBj3cWFWsKHAScfQ7)
  - 기존 Outsider와 Student로 나뉘는 부분이 제거되고 UserDetails로 통합했습니다.
  - Outsider의 결제 완료 시간 필드는 Ticket으로 옮겨졌습니다.
    - 해당 학교 학생이면 예약 즉시 결제 완료 시각 설정
    - 외부인이면 입금 확인 시 결제 완료 시각 설정
- 추후 개발 및 운영 서버에 미리 University 값들을 설정할 필요가 있습니다.

# 💡 코드 리뷰 요청사항
- 회원가입 로직이 정상적으로 동작하는지 확인 부탁드립니다.
- 추가로 테스트 코드 작성이 필요한 부분이 있는지 확인 부탁드립니다.
- 더 좋은 로직이 있다면 말씀주세요~

