### PR TITLE
[SVR-11] feat: 대학별 현재 진행중인 축제 조회 기능 추가

### DIFF
--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation project(":domain:auth-domain")
 	implementation project(":domain:user-domain")
 	implementation project(":domain:university-domain")
+	implementation project(":domain:event-domain")
 	implementation project(":modules:jwt-provider")
 }
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -1,7 +1,6 @@
 package com.uket.app.ticket.api.controller;
 
 import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
-import com.uket.domain.auth.config.userid.LoginUserId;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,9 +18,6 @@ public interface EventApi {
 
     @GetMapping(value = "/current", params = {"university"})
     ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(
-            @Parameter(hidden = true)
-            @LoginUserId Long userId,
-
             @Parameter(example = "건국대학교", description = "사용자가 선택한 학교 이름")
             @RequestParam("university")
             String university

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -1,0 +1,29 @@
+package com.uket.app.ticket.api.controller;
+
+import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
+import com.uket.domain.auth.config.userid.LoginUserId;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "축제 API", description = "축제 관련 API")
+@RestController
+@SecurityRequirement(name = "JWT")
+@RequestMapping("/api/v1/events")
+public interface EventApi {
+
+    @GetMapping(value = "/current", params = {"university"})
+    ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(
+            @Parameter(hidden = true)
+            @LoginUserId Long userId,
+
+            @Parameter(example = "건국대학교", description = "사용자가 선택한 학교 이름")
+            @RequestParam("university")
+            String university
+    );
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/DevController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/DevController.java
@@ -2,7 +2,9 @@ package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.DevApi;
 import com.uket.app.ticket.api.dto.response.TokenResponse;
+import com.uket.app.ticket.api.service.UserRegisterService;
 import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.user.dto.CreateUserDetailsDto;
 import com.uket.domain.user.dto.CreateUserDto;
 import com.uket.domain.user.dto.UserDto;
 import com.uket.domain.user.entity.Users;
@@ -20,6 +22,7 @@ public class DevController implements DevApi {
 
     private final JwtAuthTokenUtil jwtAuthTokenUtil;
     private final UserService userService;
+    private final UserRegisterService userRegisterService;
 
     @Override
     public ResponseEntity<String> test(Long userId) {
@@ -30,7 +33,10 @@ public class DevController implements DevApi {
     public ResponseEntity<TokenResponse> getToken() {
 
         Users user = userService.saveUser(generateCreateUserDto());
-        UserDto userDto = generateUserDto(user);
+        userRegisterService.register(user.getId(),generateCreateUserDetailsDto(),"건국대학교");
+
+        Users findUser = userService.findById(user.getId());
+        UserDto userDto = generateUserDto(findUser);
 
         Boolean isRegistered = userDto.isRegistered();
 
@@ -61,6 +67,15 @@ public class DevController implements DevApi {
                 .email("abc@naver.com")
                 .name("테스트")
                 .role(UserRole.ROLE_USER)
+                .build();
+    }
+
+    private CreateUserDetailsDto generateCreateUserDetailsDto() {
+        return CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터공학부")
+                .studentCode("202411032")
                 .build();
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -2,12 +2,8 @@ package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.EventApi;
 import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
-import com.uket.core.exception.ErrorCode;
+import com.uket.app.ticket.api.service.UniversityEventService;
 import com.uket.domain.event.entity.Events;
-import com.uket.domain.event.exception.EventException;
-import com.uket.domain.event.service.EventService;
-import com.uket.domain.university.service.UniversityService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -16,19 +12,14 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class EventController implements EventApi {
 
-    private final UniversityService universityService;
-    private final EventService eventService;
+    private final UniversityEventService universityEventService;
 
     @Override
-    public ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(Long userId,
-            String university) {
+    public ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(String university) {
 
-        Optional<Long> currentEvent = universityService.getCurrentEvent(university);
-        if (currentEvent.isPresent()) {
-            Events event = eventService.findById(currentEvent.get());
-            CurrentEventResponse response = CurrentEventResponse.from(event);
-            return ResponseEntity.ok(response);
-        }
-        throw new EventException(ErrorCode.NOT_FOUND_CURRENT_EVENT);
+        Events event = universityEventService.getCurrentEventOfUniversity(university);
+
+        CurrentEventResponse response = CurrentEventResponse.from(event);
+        return ResponseEntity.ok(response);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -1,0 +1,34 @@
+package com.uket.app.ticket.api.controller.impl;
+
+import com.uket.app.ticket.api.controller.EventApi;
+import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.service.EventService;
+import com.uket.domain.university.service.UniversityService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class EventController implements EventApi {
+
+    private final UniversityService universityService;
+    private final EventService eventService;
+
+    @Override
+    public ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(Long userId,
+            String university) {
+
+        Optional<Long> currentEvent = universityService.getCurrentEvent(university);
+        if (currentEvent.isPresent()) {
+            Events event = eventService.findById(currentEvent.get());
+            CurrentEventResponse response = CurrentEventResponse.from(event);
+            return ResponseEntity.ok(response);
+        }
+        throw new EventException(ErrorCode.NOT_FOUND_EVENT);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -29,6 +29,6 @@ public class EventController implements EventApi {
             CurrentEventResponse response = CurrentEventResponse.from(event);
             return ResponseEntity.ok(response);
         }
-        throw new EventException(ErrorCode.NOT_FOUND_EVENT);
+        throw new EventException(ErrorCode.NOT_FOUND_CURRENT_EVENT);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
@@ -1,0 +1,21 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.event.entity.Events;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record CurrentEventResponse(
+
+        String name,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static CurrentEventResponse from(Events event) {
+        return CurrentEventResponse.builder()
+                .name(event.getName())
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .build();
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UniversityEventService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UniversityEventService.java
@@ -1,0 +1,29 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.service.EventService;
+import com.uket.domain.university.service.UniversityService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UniversityEventService {
+
+    private final UniversityService universityService;
+    private final EventService eventService;
+
+    public Events getCurrentEventOfUniversity(String university) {
+        Optional<Long> currentEvent = universityService.getCurrentEvent(university);
+
+        if (currentEvent.isPresent()) {
+            return eventService.findById(currentEvent.get());
+        }
+        throw new EventException(ErrorCode.NOT_FOUND_CURRENT_EVENT);
+    }
+}

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,1 +1,6 @@
+insert into events (name,start_date,end_date) values ('녹색지대',CURDATE(),CURDATE());
 insert into university (name) values ('일반인'),('건국대학교');
+UPDATE university
+    JOIN events ON university.name = '건국대학교' AND events.name = '녹색지대'
+    SET university.current_event = events.event_id
+WHERE university.name = '건국대학교';

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,1 +1,1 @@
-insert into university (name) values ('외부인'),('건국대학교');
+insert into university (name) values ('일반인'),('건국대학교');

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/EventControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/EventControllerTest.java
@@ -1,0 +1,162 @@
+package com.uket.app.ticket.api.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.uket.app.ticket.api.service.UserRegisterService;
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.auth.dto.response.AuthToken;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.repository.UniversityRepository;
+import com.uket.domain.user.dto.CreateUserDetailsDto;
+import com.uket.domain.user.dto.CreateUserDto;
+import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.enums.Platform;
+import com.uket.domain.user.enums.UserRole;
+import com.uket.domain.user.service.UserService;
+import com.uket.modules.jwt.auth.constants.JwtValues;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class EventControllerTest {
+
+    private static final String BASE_URL = "/api/v1/events";
+    private static final String UNIVERSITY_OUTSIDER = "일반인";
+    private static final String UNIVERSITY_KONKUK = "건국대학교";
+    private static final String EVENT_KONKUK = "녹색지대";
+    private static final String QUERY_STRING_UNIVERSITY = "university";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserRegisterService userRegisterService;
+    @Autowired
+    private UniversityRepository universityRepository;
+    @Autowired
+    private EventRepository eventRepository;
+
+    private Users user;
+    private String accessToken;
+
+    @BeforeEach
+    void beforeEach() {
+        CreateUserDto createUserDto = CreateUserDto.builder()
+                .name("test")
+                .role(UserRole.ROLE_USER)
+                .platform(Platform.KAKAO)
+                .platformId("1234")
+                .email("abc@naver.com")
+                .build();
+
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .studentMajor("컴퓨터공학부")
+                .studentCode("202411032")
+                .build();
+
+        user = userService.saveUser(createUserDto);
+
+        Events event = eventRepository.save(
+                Events.builder()
+                        .name(EVENT_KONKUK)
+                        .startDate(LocalDate.now())
+                        .endDate(LocalDate.now())
+                        .build()
+        );
+        universityRepository.save(
+                University.builder()
+                        .name(UNIVERSITY_OUTSIDER)
+                        .build()
+        );
+        universityRepository.save(
+                University.builder()
+                        .name(UNIVERSITY_KONKUK)
+                        .currentEvent(event.getId())
+                        .build()
+        );
+
+        AuthToken authToken = userRegisterService.register(user.getId(), createUserDetailsDto, UNIVERSITY_KONKUK);
+        accessToken = String.join("", JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX, authToken.accessToken());
+    }
+
+    @Test
+    void 존재하는_대학교의_현재_진행중인_축제를_조회할_수_있다() throws Exception {
+
+        ResultActions perform = mockMvc.perform(
+                get(BASE_URL + "/current")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .param(QUERY_STRING_UNIVERSITY,UNIVERSITY_KONKUK)
+        );
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(EVENT_KONKUK))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists());
+    }
+
+    @Test
+    void 존재하지_않는_대학의_경우_예외를_반환한다() throws Exception {
+
+        ResultActions perform = mockMvc.perform(
+                get(BASE_URL + "/current")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .param(QUERY_STRING_UNIVERSITY,"")
+        );
+
+        perform.andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND_UNIVERSITY.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage()));
+    }
+
+    @Test
+    void 일빈인으로_요청한_경우_존재하지_않는_대학으로_처리한다() throws Exception {
+        ResultActions perform = mockMvc.perform(
+                get(BASE_URL + "/current")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .param(QUERY_STRING_UNIVERSITY,UNIVERSITY_OUTSIDER)
+        );
+
+        perform.andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND_UNIVERSITY.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage()));
+    }
+
+    @Test
+    void 진행중인_이벤트가_없는_경우_예외를_반환한다() throws Exception {
+        String UNIV_SEJONG = "세종대학교";
+
+        universityRepository.save(
+                University.builder()
+                        .name(UNIV_SEJONG)
+                        .build()
+        );
+
+        ResultActions perform = mockMvc.perform(
+                get(BASE_URL + "/current")
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .param(QUERY_STRING_UNIVERSITY, UNIV_SEJONG)
+        );
+
+        perform.andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND_CURRENT_EVENT.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND_CURRENT_EVENT.getMessage()));
+    }
+}

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uket.app.ticket.api.dto.request.UserRegisterRequest;
 import com.uket.app.ticket.api.dto.response.TokenResponse;
 import com.uket.app.ticket.api.util.AuthTokenGenerator;
-import com.uket.core.dto.response.ErrorResponse;
-import com.uket.core.exception.ErrorCode;
 import com.uket.domain.auth.dto.response.AuthToken;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.repository.UniversityRepository;
@@ -34,7 +32,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @SpringBootTest
 @Transactional
@@ -71,7 +68,7 @@ class UserControllerTest {
 
         user = userService.saveUser(createUserDto);
 
-        universityRepository.save(University.builder().name("외부인").build());
+        universityRepository.save(University.builder().name("일반인").build());
         universityRepository.save(University.builder().name("건국대학교").build());
     }
 

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UniversityEventServiceTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UniversityEventServiceTest.java
@@ -1,0 +1,88 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.exception.UniversityException;
+import com.uket.domain.university.repository.UniversityRepository;
+import com.uket.domain.user.dto.CreateUserDto;
+import com.uket.domain.user.enums.Platform;
+import com.uket.domain.user.enums.UserRole;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+class UniversityEventServiceTest {
+
+    private static final String UNIVERSITY_OUTSIDER = "일반인";
+    private static final String UNIVERSITY_KONKUK = "건국대학교";
+    private static final String EVENT_KONKUK = "녹색지대";
+
+
+    @Autowired
+    UniversityEventService universityEventService;
+    @Autowired
+    UniversityRepository universityRepository;
+    @Autowired
+    EventRepository eventRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        CreateUserDto createUserDto = CreateUserDto.builder()
+                .name("test")
+                .role(UserRole.ROLE_USER)
+                .platform(Platform.KAKAO)
+                .platformId("1234")
+                .email("abc@naver.com")
+                .build();
+
+        universityRepository.save(University.builder().name(UNIVERSITY_OUTSIDER).build());
+    }
+
+    @Test
+    void 축제를_진행중인_대학의_경우_축제_id를_반환한다() {
+        Events event = eventRepository.save(
+                Events.builder()
+                        .name(EVENT_KONKUK)
+                        .build()
+        );
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).currentEvent(event.getId()).build());
+
+        Assertions.assertThat(universityEventService.getCurrentEventOfUniversity(UNIVERSITY_KONKUK).getId())
+                .isEqualTo(event.getId());
+    }
+
+    @Test
+    void 축제를_진행중이지_않은_대학의_경우_예외를_반환한다() {
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).build());
+
+        Assertions.assertThatThrownBy(() -> universityEventService.getCurrentEventOfUniversity(UNIVERSITY_KONKUK))
+                .isInstanceOf(EventException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_CURRENT_EVENT.getMessage());
+    }
+
+    @Test
+    void 존재하지_않는_대학의_경우_예외를_반환한다() {
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).build());
+
+        Assertions.assertThatThrownBy(() -> universityEventService.getCurrentEventOfUniversity(""))
+                .isInstanceOf(UniversityException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage());
+    }
+
+    @Test
+    void 대학이름을_일반인으로_요청한_경우_예외를_반환한다() {
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).build());
+
+        Assertions.assertThatThrownBy(() -> universityEventService.getCurrentEventOfUniversity(UNIVERSITY_OUTSIDER))
+                .isInstanceOf(UniversityException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage());
+    }
+}

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @Transactional
 class UserRegisterServiceTest {
 
-    private static final String UNIVERSITY_OUTSIDER = "외부인";
+    private static final String UNIVERSITY_OUTSIDER = "일반인";
     private static final String UNIVERSITY_KONKUK = "건국대학교";
 
     @Autowired

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -33,11 +33,18 @@ public enum ErrorCode {
      */
     NOT_FOUND_USER(404,"US0001", "해당 사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_USER(409,"US0002", "이미 가입된 사용자입니다."),
+    NOT_REGISTERED_USER(400,"US0003", "가입되지 않은 사용자입니다. 회원가입 후 이용해주세요"),
 
     /**
      * University Errors
      */
-    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다.");
+    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다."),
+
+    /**
+     * Events Errors
+     */
+    NOT_FOUND_EVENT(404,"EV0001", "해당 축제를 찾을 수 없습니다.");
+
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
     /**
      * Events Errors
      */
-    NOT_FOUND_EVENT(404,"EV0001", "해당 축제를 찾을 수 없습니다.");
+    NOT_FOUND_EVENT(404,"EV0001", "해당 축제를 찾을 수 없습니다."),
+    NOT_FOUND_CURRENT_EVENT(404,"EV0002", "진행중인 축제를 찾을 수 없습니다.");
 
 
     private final int status;

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -2,18 +2,29 @@ package com.uket.domain.auth.config;
 
 import com.uket.domain.auth.config.register.IsRegisteredArgumentResolver;
 import com.uket.domain.auth.config.userid.LoginUserArgumentResolver;
+import com.uket.domain.auth.interceptor.LoginInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 public class AuthConfig implements WebMvcConfigurer {
 
+    private final LoginInterceptor loginInterceptor;
     private final LoginUserArgumentResolver loginUserArgumentResolver;
     private final IsRegisteredArgumentResolver isRegisteredArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .excludePathPatterns("/api/v1/dev/**")
+                .excludePathPatterns("/api/v1/auth/**","/api/v1/users/register")
+                .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error");
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/interceptor/AuthorizationExtractor.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/interceptor/AuthorizationExtractor.java
@@ -1,0 +1,20 @@
+package com.uket.domain.auth.interceptor;
+
+import static com.uket.modules.jwt.auth.constants.JwtValues.JWT_AUTHORIZATION_HEADER;
+import static com.uket.modules.jwt.auth.constants.JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.auth.exception.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AuthorizationExtractor {
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(JWT_AUTHORIZATION_HEADER);
+
+        if (accessToken == null) {
+            throw new AuthException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+        return accessToken.replace(JWT_AUTHORIZATION_VALUE_PREFIX, "");
+    }
+}

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/interceptor/LoginInterceptor.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/interceptor/LoginInterceptor.java
@@ -1,0 +1,63 @@
+package com.uket.domain.auth.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uket.core.dto.response.ErrorResponse;
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.auth.exception.AuthException;
+import com.uket.domain.auth.validator.TokenValidator;
+import com.uket.modules.jwt.auth.JwtAuthTokenUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginInterceptor implements HandlerInterceptor {
+
+    private final TokenValidator tokenValidator;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (isPreflight(request) || isSwaggerRequest(request)) {
+            return true;
+        }
+
+        String token = AuthorizationExtractor.extractAccessToken(request);
+        try{
+            tokenValidator.validateRegistered(token);
+        }catch (AuthException exception) {
+            ErrorCode errorCode =  exception.getErrorCode();
+            writeErrorResponse(response, errorCode);
+            log.warn("[AuthException] {}: {}", errorCode.getCode(), errorCode.getMessage(), exception);
+            return false;
+        }
+        return true;
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(ErrorResponse.of(errorCode)));
+    }
+
+    private boolean isSwaggerRequest(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.contains("swagger") || uri.contains("api-docs") || uri.contains("webjars");
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return request.getMethod().equals(HttpMethod.OPTIONS.toString());
+    }
+}

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/validator/TokenValidator.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/validator/TokenValidator.java
@@ -37,4 +37,10 @@ public class TokenValidator {
             throw new AuthException(ErrorCode.TOKEN_NOT_EXPIRED);
         }
     }
+
+    public void validateRegistered(String accessToken) {
+        if (Boolean.FALSE.equals(jwtAuthTokenUtil.isRegistered(accessToken))) {
+            throw new AuthException(ErrorCode.NOT_REGISTERED_USER);
+        }
+    }
 }

--- a/domain/event-domain/build.gradle
+++ b/domain/event-domain/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    implementation project(":domain:core-domain")
+    implementation project(":domain:university-domain")
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.named('bootJar') {
+    enabled = false
+}
+
+tasks.named('jar') {
+    enabled = true
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
@@ -1,0 +1,39 @@
+package com.uket.domain.event.entity;
+
+import com.uket.domain.core.entity.BaseEntity;
+import com.uket.domain.university.entity.University;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Events extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_id")
+    private University university;
+
+    private String name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/exception/EventException.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/exception/EventException.java
@@ -1,0 +1,11 @@
+package com.uket.domain.event.exception;
+
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
+
+public class EventException extends BaseException {
+
+    public EventException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/repository/EventRepository.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package com.uket.domain.event.repository;
+
+import com.uket.domain.event.entity.Events;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Events, Long> {
+
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -1,0 +1,12 @@
+package com.uket.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventService {
+
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -1,5 +1,9 @@
 package com.uket.domain.event.service;
 
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class EventService {
 
+    private final EventRepository eventRepository;
+
+    public Events findById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(ErrorCode.NOT_FOUND_EVENT));
+    }
 }

--- a/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
+++ b/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
@@ -1,0 +1,35 @@
+package com.uket.domain.event.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.repository.EventRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @InjectMocks
+    EventService eventService;
+
+    @Mock
+    EventRepository eventRepository;
+
+    @Test
+    void 해당_축제가_존재하지_않는_경우_예외를_반환한다() {
+
+        when(eventRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.findById(1L))
+                .isInstanceOf(EventException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_EVENT.getMessage());
+    }
+}

--- a/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
@@ -27,4 +27,5 @@ public class University {
     private Long id;
     private String name;
     private String logoUrl;
+    private Long currentEvent;
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UniversityService {
 
-    private static final String DEFAULT_UNIVERSITY_NAME = "외부인";
+    private static final String DEFAULT_UNIVERSITY_NAME = "일반인";
 
     private final UniversityRepository universityRepository;
 
@@ -27,10 +27,10 @@ public class UniversityService {
                 .orElseThrow(()-> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
     }
 
-    public Long getCurrentEvent(String name) {
+    public Optional<Long> getCurrentEvent(String name) {
         University university = universityRepository.findByName(name)
                 .orElseThrow(() -> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
 
-        return university.getCurrentEvent();
+        return Optional.ofNullable(university.getCurrentEvent());
     }
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -26,4 +26,11 @@ public class UniversityService {
         return universityRepository.findByName(DEFAULT_UNIVERSITY_NAME)
                 .orElseThrow(()-> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
     }
+
+    public Long getCurrentEvent(String name) {
+        University university = universityRepository.findByName(name)
+                .orElseThrow(() -> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
+
+        return university.getCurrentEvent();
+    }
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -28,6 +28,10 @@ public class UniversityService {
     }
 
     public Optional<Long> getCurrentEvent(String name) {
+
+        if (name.equals(DEFAULT_UNIVERSITY_NAME)) {
+            throw new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY);
+        }
         University university = universityRepository.findByName(name)
                 .orElseThrow(() -> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
 

--- a/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
+++ b/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
@@ -1,10 +1,12 @@
 package com.uket.domain.university.service;
 
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.uket.core.exception.ErrorCode;
+import com.uket.domain.university.entity.University;
 import com.uket.domain.university.exception.UniversityException;
 import com.uket.domain.university.repository.UniversityRepository;
 import java.util.Optional;
@@ -27,8 +29,46 @@ class UniversityServiceTest {
     void 기본값이_존재하지_않을_경우_예외를_발생시킨다() {
         when(universityRepository.findByName(any())).thenReturn(Optional.empty());
 
-        Assertions.assertThatThrownBy(() -> universityService.getDefault())
+        assertThatThrownBy(() -> universityService.getDefault())
                 .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage())
                 .isInstanceOf(UniversityException.class);
+    }
+
+    @Test
+    void 요청한_대학이_존재하지_않는_경우_예외를_발생시킨다() {
+
+        when(universityRepository.findByName(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> universityService.getCurrentEvent(""))
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage())
+                .isInstanceOf(UniversityException.class);
+    }
+
+    @Test
+    void 요청한_대학이_일반인인_경우_예외를_발생시킨다() {
+
+        assertThatThrownBy(() -> universityService.getCurrentEvent("일반인"))
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage())
+                .isInstanceOf(UniversityException.class);
+    }
+
+    @Test
+    void 요청한_대학이_진행중인_축제가_없는_경우_null을_반환한다() {
+
+        when(universityRepository.findByName(any())).thenReturn(
+                Optional.of(University.builder().name("건국대학교").build())
+        );
+
+        Assertions.assertThat(universityService.getCurrentEvent("건국대학교")).isEmpty();
+    }
+
+    @Test
+    void 요청한_대학이_진행중인_축제가_있는_경우_축제의_id를_반환한다() {
+
+        when(universityRepository.findByName(any())).thenReturn(
+                Optional.of(University.builder().name("건국대학교").currentEvent(1L).build())
+        );
+
+        Assertions.assertThat(universityService.getCurrentEvent("건국대학교")).isNotEmpty();
     }
 }


### PR DESCRIPTION
# 📌 개요
- **대학별 현재 진행중인 축제 조회 기능**을 추가했습니다.
- 회원가입 여부 확인 `interceptor` 추가했습니다.
  - `"/api/v1/auth/**"`,`"/api/v1/users/register"`,`"/api/v1/dev/**"` 외 모든 요청에 대해서 사용자의 회원가입 여부를 체크합니다.
  - 만약 회원가입 없이 동작해야 하는 `API`라면 `AuthConfig` 클래스의 `addInterceptors()` 메소드에서 `excludePathPatterns`을 추가해주세요.

# 💻 작업사항
- [x] 축제 도메인 관련 기본 세팅
- [x] 회원가입 여부 확인 interceptor 추가
- [x] 회원가입 시 대학을 입력하지 않는 경우 기존 `외부인`으로 설정되던 값을 `일반인`으로 변경
- [x] 대학별 현재 진행중인 축제 조회 기능 추가
- [x] 관련 테스트 추가

# ❌ 주의사항
- 추후 개발하는 `API`에 대해서 회원가입이 필요없는 경우 위 개요의 `interceptor` 부분을 참고해주세요.
- 현재는 축제에 대한 기본 정보만 반환되지만 추후 축제의 공연 정보도 함께 반환되도록 수정해야 합니다.
- [기존 ERD](https://www.erdcloud.com/d/WBj3cWFWsKHAScfQ7)에서 수정된 부분이 있으니 참고 바랍니다.

# 💡 코드 리뷰 요청사항
- 로직이 제대로 동작하는지 확인 부탁드립니다.
- 발견하지 못한 예외상황이 있는지 확인 부탁드립니다.
- 더 좋은 로직이 있다면 코맨트 남겨주세요!
