### PR TITLE
[SVR-17] fix: 회원 상세 정보 학교 이메일 추가

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UserController.java
@@ -32,6 +32,7 @@ public class UserController implements UserApi {
         return CreateUserDetailsDto.builder()
                 .depositorName(request.depositorName())
                 .phoneNumber(request.phoneNumber())
+                .universityEmail(request.universityEmail())
                 .studentMajor(request.studentMajor())
                 .studentCode(request.studentCode())
                 .build();

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/UserRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.uket.app.ticket.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
@@ -14,6 +15,9 @@ public record UserRegisterRequest(
         String phoneNumber,
         @Schema(description = "대학 이름", example = "건국대학교")
         String university,
+        @Schema(description = "학교 이메일", example = "abc1234@konkuk.ac.kr")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String universityEmail,
         @Schema(description = "학과", example = "컴퓨터공학부")
         String studentMajor,
         @Schema(description = "학번", example = "202412345")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserRegisterService.java
@@ -1,12 +1,14 @@
 package com.uket.app.ticket.api.service;
 
 import com.uket.app.ticket.api.util.AuthTokenGenerator;
+import com.uket.core.exception.ErrorCode;
 import com.uket.domain.auth.dto.response.AuthToken;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.service.UniversityService;
 import com.uket.domain.user.dto.CreateUserDetailsDto;
 import com.uket.domain.user.entity.UserDetails;
 import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.exception.UserException;
 import com.uket.domain.user.service.UserDetailsService;
 import com.uket.domain.user.service.UserService;
 import java.util.Optional;
@@ -28,9 +30,16 @@ public class UserRegisterService {
     public AuthToken register(Long userId, CreateUserDetailsDto createUserDetailsDto, String university) {
         Users findUser = userService.findById(userId);
 
-        UserDetails userDetails = userDetailsService.saveUserDetails(createUserDetailsDto);
         Optional<University> findUniversity = universityService.findByName(university);
 
+        String universityEmail = createUserDetailsDto.universityEmail();
+        findUniversity.ifPresent(univ -> {
+            if(!universityEmail.contains(univ.getEmailPostFix())){
+                throw new UserException(ErrorCode.NOT_MATCH_UNIVERSITY_EMAIL);
+            }
+        });
+
+        UserDetails userDetails = userDetailsService.saveUserDetails(createUserDetailsDto);
         findUser.register(userDetails, findUniversity.orElse(universityService.getDefault()));
         return authTokenGenerator.generateAuthToken(findUser);
     }

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,1 +1,1 @@
-insert into university (name) values ('외부인'),('건국대학교');
+insert into university (name,email_post_fix) values ('외부인',null),('건국대학교','@konkuk.ac.kr');

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/EventControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/EventControllerTest.java
@@ -67,6 +67,7 @@ class EventControllerTest {
 
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
+                .universityEmail("abc@konkuk.ac.kr")
                 .phoneNumber("01012341234")
                 .studentMajor("컴퓨터공학부")
                 .studentCode("202411032")
@@ -89,6 +90,7 @@ class EventControllerTest {
         universityRepository.save(
                 University.builder()
                         .name(UNIVERSITY_KONKUK)
+                        .emailPostFix("@konkuk.ac.kr")
                         .currentEvent(event.getId())
                         .build()
         );

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UserControllerTest.java
@@ -72,14 +72,14 @@ class UserControllerTest {
         user = userService.saveUser(createUserDto);
 
         universityRepository.save(University.builder().name("외부인").build());
-        universityRepository.save(University.builder().name("건국대학교").build());
+        universityRepository.save(University.builder().name("건국대학교").emailPostFix("@konkuk.ac.kr").build());
     }
 
     @Test
     void 회원가입시_토큰이_재발급된다() throws Exception {
 
         UserRegisterRequest request = new UserRegisterRequest("홍길동",
-                "01012341234", "건국대학교", "컴퓨터공학부", "12341234");
+                "01012341234", "건국대학교", "abc123@konkuk.ac.kr","컴퓨터공학부", "12341234");
         AuthToken authToken = authTokenGenerator.generateAuthToken(user);
         String accessToken = String.join("", JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX, authToken.accessToken());
 
@@ -101,7 +101,7 @@ class UserControllerTest {
     void 재발급된_토큰은_회원가입된_상태여야_한다() throws Exception {
 
         UserRegisterRequest request = new UserRegisterRequest("홍길동",
-                "01012341234", "건국대학교", "컴퓨터공학부", "12341234");
+                "01012341234", "건국대학교", "abc123@konkuk.ac.kr","컴퓨터공학부", "12341234");
         AuthToken authToken = authTokenGenerator.generateAuthToken(user);
         String accessToken = String.join("", JwtValues.JWT_AUTHORIZATION_VALUE_PREFIX, authToken.accessToken());
 

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
@@ -2,6 +2,7 @@ package com.uket.app.ticket.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.uket.core.exception.ErrorCode;
 import com.uket.domain.auth.dto.response.AuthToken;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.repository.UniversityRepository;
@@ -11,8 +12,10 @@ import com.uket.domain.user.entity.UserDetails;
 import com.uket.domain.user.entity.Users;
 import com.uket.domain.user.enums.Platform;
 import com.uket.domain.user.enums.UserRole;
+import com.uket.domain.user.exception.UserException;
 import com.uket.domain.user.service.UserService;
 import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +69,7 @@ class UserRegisterServiceTest {
     }
 
     @Test
-    void 대학을_입력하지_않을_시_외부인으로_처리된다() {
+    void 대학을_입력할_시_해당_대학으로_처리된다() {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
@@ -82,7 +85,7 @@ class UserRegisterServiceTest {
     }
 
     @Test
-    void 대학을_입력할_시_해당_대학으로_처리된다() {
+    void 대학을_입력하지_않을_시_외부인으로_처리된다() {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
@@ -136,7 +139,18 @@ class UserRegisterServiceTest {
 
     @Test
     void 대학_이메일과_대학이_다를_경우_예외를_반환한다() {
+        CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
+                .depositorName("홍길동")
+                .phoneNumber("01012341234")
+                .universityEmail("abc123@naver.com")
+                .studentMajor("컴퓨터 공학부")
+                .studentCode("1234")
+                .build();
 
-
+        Long userId = user.getId();
+        Assertions.assertThatThrownBy(
+                        () -> userRegisterService.register(userId, createUserDetailsDto, UNIVERSITY_KONKUK))
+                .isInstanceOf(UserException.class)
+                .hasMessage(ErrorCode.NOT_MATCH_UNIVERSITY_EMAIL.getMessage());
     }
 }

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/service/UserRegisterServiceTest.java
@@ -47,7 +47,7 @@ class UserRegisterServiceTest {
         user = userService.saveUser(createUserDto);
 
         universityRepository.save(University.builder().name(UNIVERSITY_OUTSIDER).build());
-        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).build());
+        universityRepository.save(University.builder().name(UNIVERSITY_KONKUK).emailPostFix("@konkuk.ac.kr").build());
     }
 
     @Test
@@ -56,8 +56,6 @@ class UserRegisterServiceTest {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
-                .studentMajor("컴퓨터 공학부")
-                .studentCode("1234")
                 .build();
 
         AuthToken authToken = userRegisterService.register(user.getId(), createUserDetailsDto, null);
@@ -72,6 +70,7 @@ class UserRegisterServiceTest {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
+                .universityEmail("abc123@konkuk.ac.kr")
                 .studentMajor("컴퓨터 공학부")
                 .studentCode("1234")
                 .build();
@@ -87,8 +86,6 @@ class UserRegisterServiceTest {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
-                .studentMajor("컴퓨터 공학부")
-                .studentCode("1234")
                 .build();
 
         userRegisterService.register(user.getId(), createUserDetailsDto, null);
@@ -102,8 +99,6 @@ class UserRegisterServiceTest {
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName("홍길동")
                 .phoneNumber("01012341234")
-                .studentMajor("컴퓨터 공학부")
-                .studentCode("1234")
                 .build();
 
         userRegisterService.register(user.getId(), createUserDetailsDto, null);
@@ -116,23 +111,32 @@ class UserRegisterServiceTest {
     void 회원가입이_완료되면_회원의_세부정보가_저장된다() {
         String depositorName = "홍길동";
         String phoneNumber = "01012341234";
+        String email = "abc123@konkuk.ac.kr";
         String major = "컴퓨터 공학부";
         String code = "1234";
 
         CreateUserDetailsDto createUserDetailsDto = CreateUserDetailsDto.builder()
                 .depositorName(depositorName)
                 .phoneNumber(phoneNumber)
+                .universityEmail(email)
                 .studentMajor(major)
                 .studentCode(code)
                 .build();
 
-        userRegisterService.register(user.getId(), createUserDetailsDto, null);
+        userRegisterService.register(user.getId(), createUserDetailsDto, UNIVERSITY_KONKUK);
         Users findUser = userService.findById(user.getId());
         UserDetails userDetails = findUser.getUserDetails();
 
         assertThat(userDetails.getDepositorName()).isEqualTo(depositorName);
         assertThat(userDetails.getPhoneNumber()).isEqualTo(phoneNumber);
+        assertThat(userDetails.getUniversityEmail()).isEqualTo(email);
         assertThat(userDetails.getStudentMajor()).isEqualTo(major);
         assertThat(userDetails.getStudentCode()).isEqualTo(code);
+    }
+
+    @Test
+    void 대학_이메일과_대학이_다를_경우_예외를_반환한다() {
+
+
     }
 }

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
      * University Errors
      */
     NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다."),
-    NOT_MATCH_UNIVERSITY_EMAIL(400,"UN0002", "대학 이메일 정보가 잘못되었습니다.");
+    NOT_MATCH_UNIVERSITY_EMAIL(400,"UN0002", "대학 이메일 정보가 잘못되었습니다."),
 
     /**
      * Events Errors

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -37,7 +37,9 @@ public enum ErrorCode {
     /**
      * University Errors
      */
-    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다.");
+    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다."),
+    NOT_MATCH_UNIVERSITY_EMAIL(400,"UN0002", "대학 이메일 정보가 잘못되었습니다.");
+
 
     private final int status;
     private final String code;

--- a/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/entity/University.java
@@ -26,5 +26,6 @@ public class University {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
+    private String emailPostFix;
     private String logoUrl;
 }

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -19,6 +19,9 @@ public class UniversityService {
     private final UniversityRepository universityRepository;
 
     public Optional<University> findByName(String name) {
+        if (DEFAULT_UNIVERSITY_NAME.equals(name)) {
+            return Optional.empty();
+        }
         return universityRepository.findByName(name);
     }
 

--- a/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
+++ b/domain/university-domain/src/test/java/com/uket/domain/university/service/UniversityServiceTest.java
@@ -1,6 +1,8 @@
 package com.uket.domain.university.service;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -17,6 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class UniversityServiceTest {
+
+    private static final String DEFAULT_UNIVERSITY_NAME = "외부인";
+
     @InjectMocks
     UniversityService universityService;
 
@@ -24,10 +29,16 @@ class UniversityServiceTest {
     UniversityRepository universityRepository;
 
     @Test
+    void 일반인을_대학으로_요청한_경우_빈_객체를_반환한다() {
+        assertThat(universityService.findByName(DEFAULT_UNIVERSITY_NAME))
+                .isEmpty();
+    }
+
+    @Test
     void 기본값이_존재하지_않을_경우_예외를_발생시킨다() {
         when(universityRepository.findByName(any())).thenReturn(Optional.empty());
 
-        Assertions.assertThatThrownBy(() -> universityService.getDefault())
+        assertThatThrownBy(() -> universityService.getDefault())
                 .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage())
                 .isInstanceOf(UniversityException.class);
     }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/dto/CreateUserDetailsDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 public record CreateUserDetailsDto(
         String depositorName,
         String phoneNumber,
+        String universityEmail,
         String studentMajor,
         String studentCode
 ) {

--- a/domain/user-domain/src/main/java/com/uket/domain/user/entity/UserDetails.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/entity/UserDetails.java
@@ -22,8 +22,10 @@ public class UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_details_id")
     private Long id;
-    String depositorName;
-    String phoneNumber;
-    String studentMajor;
-    String studentCode;
+
+    private String depositorName;
+    private String phoneNumber;
+    private String studentMajor;
+    private String studentCode;
+    private String universityEmail;
 }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/service/UserDetailsService.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/service/UserDetailsService.java
@@ -20,6 +20,7 @@ public class UserDetailsService {
         UserDetails userDetails = UserDetails.builder()
                 .depositorName(createUserDetailsDto.depositorName())
                 .phoneNumber(createUserDetailsDto.phoneNumber())
+                .universityEmail(createUserDetailsDto.universityEmail())
                 .studentMajor(createUserDetailsDto.studentMajor())
                 .studentCode(createUserDetailsDto.studentCode())
                 .build();


### PR DESCRIPTION
# 📌 개요
- 기존 회원 상세 정보를 추가할 때, 학교 이메일을 입력받지 않던 부분을 수정했습니다.

# 💻 작업사항
- [x] 회원 상세 정보에 학교 이메일 추가
- [x] 요청한 이메일 정보가 해당 대학의 이메일 정보와 다를 경우 예외처리 로직 추가

# ❌ 주의사항
- 추후 대학을 추가할 때, 이메일 정보도 같이 추가되어야 합니다.

# 💡 코드 리뷰 요청사항
- 학교 이메일관련 설정이 추가로 필요한 부분이 있는지 확인 부탁드립니다.
- 더 괜찮은 로직이 있다면 추천 부탁드려요~~
