### PR TITLE
[SVR-12] feat: 축제 별 공연 조회 기능 추가

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/AuthApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/AuthApi.java
@@ -32,18 +32,18 @@ public interface AuthApi {
             examples = {
                     @ExampleObject(name = "CM0002", description = "잘못된 플랫폼을 입력할 시 발생합니다.",
                             value = """
-                            {"code": "CM0002", "message": "유효하지 않은 입력입니다."}
-                            """
+                                    {"code": "CM0002", "message": "유효하지 않은 입력입니다."}
+                                    """
                     ),
                     @ExampleObject(name = "AU0006", description = "지원하지 않는 플랫폼을 입력할 시 발생합니다.",
                             value = """
-                            {"code": "AU0006", "message": "유효하지 않은 플랫폼입니다."}
-                            """
+                                    {"code": "AU0006", "message": "유효하지 않은 플랫폼입니다."}
+                                    """
                     ),
                     @ExampleObject(name = "AU0002", description = "OAuth2 서버와 통신이 실패할 경우 발생합니다.",
                             value = """
-                            {"code": "AU0002", "message": "OAuth2 요청이 실패했습니다."}
-                            """
+                                    {"code": "AU0002", "message": "OAuth2 요청이 실패했습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping("/login/{provider}")
@@ -60,8 +60,8 @@ public interface AuthApi {
             examples = {
                     @ExampleObject(name = "AU0001", description = "refreshToken의 타입이 refresh가 아닌 경우 발생합니다.",
                             value = """
-                            {"code": "AU0001", "message": "올바르지 않은 유형의 토큰입니다."}
-                            """
+                                    {"code": "AU0001", "message": "올바르지 않은 유형의 토큰입니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(
@@ -69,8 +69,8 @@ public interface AuthApi {
             examples = {
                     @ExampleObject(name = "AU0005", description = "토큰이 유효하지 않은 경우 발생합니다.",
                             value = """
-                            {"code": "AU0005", "message": "유효하지 않은 토큰입니다."}
-                            """
+                                    {"code": "AU0005", "message": "유효하지 않은 토큰입니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(
@@ -78,13 +78,13 @@ public interface AuthApi {
             examples = {
                     @ExampleObject(name = "AU0008", description = "refreshToken이 만료된 경우 발생합니다.",
                             value = """
-                            {"code": "AU0008", "message": "만료된 토큰입니다."}
-                            """
+                                    {"code": "AU0008", "message": "만료된 토큰입니다."}
+                                    """
                     ),
                     @ExampleObject(name = "AU0009", description = "accessToken이 만료되지 않은 경우 발생합니다.",
                             value = """
-                            {"code": "AU0009", "message": "아직 토큰이 만료되지 않았습니다."}
-                            """
+                                    {"code": "AU0009", "message": "아직 토큰이 만료되지 않았습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
@@ -92,8 +92,8 @@ public interface AuthApi {
             examples = {
                     @ExampleObject(name = "US0001", description = "토큰에 담긴 UserId에 대한 사용자를 찾을 수 없을 때 발생합니다.",
                             value = """
-                            {"code": "US0001", "message": "해당 사용자를 찾을 수 없습니다."}
-                            """
+                                    {"code": "US0001", "message": "해당 사용자를 찾을 수 없습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping(value = "/reissue")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/DevApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/DevApi.java
@@ -1,10 +1,7 @@
 package com.uket.app.ticket.api.controller;
 
-import com.uket.domain.auth.config.userid.LoginUserId;
 import com.uket.app.ticket.api.dto.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,15 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/dev")
 public interface DevApi {
-
-    @GetMapping
-    @Operation(summary = "테스트용 api", description = "테스트를 진행합니다.")
-    @SecurityRequirement(name = "JWT")
-    ResponseEntity<String> test(
-            @Parameter(hidden = true)
-            @LoginUserId
-            Long userId
-    );
 
     @GetMapping("/token")
     @Operation(summary = "토큰 강제 발행", description = "토큰을 발급합니다.")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -1,7 +1,12 @@
 package com.uket.app.ticket.api.controller;
 
 import com.uket.app.ticket.api.dto.response.ShowResponse;
+import com.uket.core.dto.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +23,26 @@ public interface EventApi {
 
     @GetMapping("/{id}/shows")
     @Operation(summary = "공연 조회 API", description = "축제별 공연을 조회할 수 있습니다.")
+    @ApiResponse(responseCode = "200", description = "OK")
+    @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(
+                    name = "EV0001",
+                    description = "해당 축제를 찾을 수 없습니다.",
+                    value = """
+                            {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
+                            """
+                    ),
+                    @ExampleObject(
+                            name = "UN0001",
+                            description = "해당 대학을 찾을 수 없습니다.",
+                            value = """
+                            {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
+                            """
+                    )
+            },
+            schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<ShowResponse> getShows(
             @PathVariable("id")
             Long showId

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -19,11 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SecurityRequirement(name = "JWT")
 @RequestMapping("/api/v1/events")
+@ApiResponse(responseCode = "200", description = "OK")
 public interface EventApi {
 
     @GetMapping("/{id}/shows")
     @Operation(summary = "공연 조회 API", description = "축제별 공연을 조회할 수 있습니다.")
-    @ApiResponse(responseCode = "200", description = "OK")
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -26,14 +26,14 @@ public interface EventApi {
             mediaType = "application/json",
             examples = {
                     @ExampleObject(name = "EV0001", description = "해당 축제를 찾을 수 없습니다.",
-                    value = """
-                            {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
-                            """
+                            value = """
+                                    {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
+                                    """
                     ),
                     @ExampleObject(name = "UN0001", description = "해당 대학을 찾을 수 없습니다.",
                             value = """
-                            {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
-                            """
+                                    {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<ShowResponse> getShows(

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -27,22 +27,17 @@ public interface EventApi {
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {
-                    @ExampleObject(
-                    name = "EV0001",
-                    description = "해당 축제를 찾을 수 없습니다.",
+                    @ExampleObject(name = "EV0001", description = "해당 축제를 찾을 수 없습니다.",
                     value = """
                             {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
                             """
                     ),
-                    @ExampleObject(
-                            name = "UN0001",
-                            description = "해당 대학을 찾을 수 없습니다.",
+                    @ExampleObject(name = "UN0001", description = "해당 대학을 찾을 수 없습니다.",
                             value = """
                             {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
                             """
                     )
-            },
-            schema = @Schema(implementation = ErrorResponse.class)))
+            }, schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<ShowResponse> getShows(
             @PathVariable("id")
             Long showId

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "축제 API", description = "축제 관련 API")
 @RestController
-@SecurityRequirement(name = "JWT")
 @RequestMapping("/api/v1/events")
 @ApiResponse(responseCode = "200", description = "OK")
 public interface EventApi {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -1,0 +1,25 @@
+package com.uket.app.ticket.api.controller;
+
+import com.uket.app.ticket.api.dto.response.ShowResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "축제 API", description = "축제 관련 API")
+@RestController
+@SecurityRequirement(name = "JWT")
+@RequestMapping("/api/v1/events")
+public interface EventApi {
+
+    @GetMapping("/{id}/shows")
+    @Operation(summary = "공연 조회 API", description = "축제별 공연을 조회할 수 있습니다.")
+    ResponseEntity<ShowResponse> getShows(
+            @PathVariable("id")
+            Long showId
+    );
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "축제 API", description = "축제 관련 API")
 @RestController
 @RequestMapping("/api/v1/events")
+@SecurityRequirement(name = "JWT")
 @ApiResponse(responseCode = "200", description = "OK")
 public interface EventApi {
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
@@ -5,7 +5,6 @@ import com.uket.app.ticket.api.dto.response.ListResponse;
 import com.uket.domain.university.dto.UniversityDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "대학 API", description = "대학 관련 API")
 @RestController
-@SecurityRequirement(name = "JWT")
 @RequestMapping("/api/v1/universities")
 public interface UniversityApi {
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
@@ -32,6 +32,11 @@ public interface UniversityApi {
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {
+                    @ExampleObject(name = "UN0001", description = "조회한 대학이 DB에 존재하지 않을 경우 발생합니다.",
+                            value = """
+                                    {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
+                                    """
+                    ),
                     @ExampleObject(name = "EV0001", description = "진행중인 축제가 DB에 존재하지 않을 경우 발생합니다.",
                             value = """
                                     {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,13 +34,13 @@ public interface UniversityApi {
             examples = {
                     @ExampleObject(name = "EV0001", description = "진행중인 축제가 DB에 존재하지 않을 경우 발생합니다.",
                             value = """
-                            {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
-                            """
+                                    {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
+                                    """
                     ),
                     @ExampleObject(name = "EV0002", description = "해당 대학이 진행중인 축제가 존재하지 않을 경우 발생합니다.",
                             value = """
-                            {"code": "EV0002", "message": "진행중인 축제를 찾을 수 없습니다."}
-                            """
+                                    {"code": "EV0002", "message": "진행중인 축제를 찾을 수 없습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<CurrentEventResponse> getCurrentEventOfUniversity(

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
@@ -34,8 +34,8 @@ public interface UserApi {
                     @ExampleObject(name = "UN0002",
                             description = "사용자가 선택한 대학의 이메일과 입력한 이메일의 prefix가 맞지 않는 경우 발생합니다.",
                             value = """
-                            {"code": "UN0002", "message": "대학 이메일 정보가 잘못되었습니다."}
-                            """
+                                    {"code": "UN0002", "message": "대학 이메일 정보가 잘못되었습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
@@ -43,13 +43,13 @@ public interface UserApi {
             examples = {
                     @ExampleObject(name = "UN0001", description = "서버에서 대학 default 값 설정이 잘못된 경우 발생합니다.",
                             value = """
-                            {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
-                            """
+                                    {"code": "UN0001", "message": "해당 대학을 찾을 수 없습니다."}
+                                    """
                     ),
                     @ExampleObject(name = "US0001", description = "토큰에 담긴 UserId에 대한 사용자를 찾을 수 없을 때 발생합니다.",
                             value = """
-                            {"code": "US0001", "message": "해당 사용자를 찾을 수 없습니다."}
-                            """
+                                    {"code": "US0001", "message": "해당 사용자를 찾을 수 없습니다."}
+                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<AuthResponse> register(

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UserApi.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @SecurityRequirement(name = "JWT")
 @RequestMapping("/api/v1/users")
+@ApiResponse(responseCode = "200", description = "OK")
 public interface UserApi {
 
     @PostMapping("/register")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/DevController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/DevController.java
@@ -25,15 +25,10 @@ public class DevController implements DevApi {
     private final UserRegisterService userRegisterService;
 
     @Override
-    public ResponseEntity<String> test(Long userId) {
-        return ResponseEntity.ok("userId: " + userId);
-    }
-
-    @Override
     public ResponseEntity<TokenResponse> getToken() {
 
         Users user = userService.saveUser(generateCreateUserDto());
-        userRegisterService.register(user.getId(),generateCreateUserDetailsDto(),"건국대학교");
+        userRegisterService.register(user.getId(), generateCreateUserDetailsDto(), "건국대학교");
 
         Users findUser = userService.findById(user.getId());
         UserDto userDto = generateUserDto(findUser);

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -1,0 +1,31 @@
+package com.uket.app.ticket.api.controller.impl;
+
+import com.uket.app.ticket.api.controller.EventApi;
+import com.uket.app.ticket.api.dto.response.ShowResponse;
+import com.uket.domain.event.dto.ShowDto;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.service.EventService;
+import com.uket.domain.event.service.ShowService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class EventController implements EventApi {
+
+    private final EventService eventService;
+    private final ShowService showService;
+
+    @Override
+    public ResponseEntity<ShowResponse> getShows(Long eventId) {
+
+        Events event = eventService.findById(eventId);
+        String university = eventService.getUniversityName(eventId);
+        List<ShowDto> shows = showService.findByEvent(event);
+
+        ShowResponse response = ShowResponse.of(university, shows);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
@@ -9,7 +9,8 @@ public record CurrentEventResponse(
         Long id,
         String name,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        String location
 ) {
 
     public static CurrentEventResponse from(Events event) {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/CurrentEventResponse.java
@@ -19,6 +19,7 @@ public record CurrentEventResponse(
                 .name(event.getName())
                 .startDate(event.getStartDate())
                 .endDate(event.getEndDate())
+                .location(event.getLocation())
                 .build();
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ShowResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ShowResponse.java
@@ -1,0 +1,14 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.event.dto.ShowDto;
+import java.util.List;
+
+public record ShowResponse(
+        String universityName,
+        List<ShowDto> shows
+) {
+
+    public static ShowResponse of(String university, List<ShowDto> shows) {
+        return new ShowResponse(university, shows);
+    }
+}

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,7 +1,9 @@
 insert into university (name,email_post_fix) values ('일반인',null),('건국대학교','@konkuk.ac.kr'),('세종대학교','@sejong.ac.kr');
 insert into events (name,start_date,end_date) values ('녹색지대',CURDATE(),CURDATE());
 insert into shows (name,start_date,end_date,ticketing_date,total_ticket_count,location)
-values ('DAY 1',CURDATE(),CURDATE(),CURDATE(),0,'자양동'),('DAY 2',CURDATE()+1,CURDATE()+1,CURDATE()+1,0,'자양동'),('DAY 3',CURDATE()+2,CURDATE()+2,CURDATE()+2,0,'자양동');
+values ('DAY 1',CURDATE(),CURDATE(),CURDATE(),0,'서울 광진구 능동로 120 건국대학교 노천극장'),
+       ('DAY 2',CURDATE()+1,CURDATE()+1,CURDATE()+1,0,'서울 광진구 능동로 120 건국대학교 노천극장'),
+       ('DAY 3',CURDATE()+2,CURDATE()+2,CURDATE()+2,0,'서울 광진구 능동로 120 건국대학교 노천극장');
 UPDATE university
     JOIN events ON university.name = '건국대학교' AND events.name = '녹색지대'
     SET university.current_event = events.event_id

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,5 +1,7 @@
 insert into university (name,email_post_fix) values ('일반인',null),('건국대학교','@konkuk.ac.kr'),('세종대학교','@sejong.ac.kr');
 insert into events (name,start_date,end_date) values ('녹색지대',CURDATE(),CURDATE());
+insert into shows (name,start_date,end_date,ticketing_date,total_ticket_count,location)
+values ('DAY 1',CURDATE(),CURDATE(),CURDATE(),0,'자양동'),('DAY 2',CURDATE()+1,CURDATE()+1,CURDATE()+1,0,'자양동'),('DAY 3',CURDATE()+2,CURDATE()+2,CURDATE()+2,0,'자양동');
 UPDATE university
     JOIN events ON university.name = '건국대학교' AND events.name = '녹색지대'
     SET university.current_event = events.event_id
@@ -8,3 +10,7 @@ UPDATE events
     JOIN university ON university.current_event = events.event_id
     SET events.university_id = university.university_id
 WHERE university.current_event = events.event_id;
+UPDATE shows
+    JOIN events
+SET shows.event_id = events.event_id
+WHERE events.name = '녹색지대';

--- a/application/ticket-app-api/src/main/resources/data.sql
+++ b/application/ticket-app-api/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 insert into university (name,email_post_fix) values ('일반인',null),('건국대학교','@konkuk.ac.kr'),('세종대학교','@sejong.ac.kr');
-insert into events (name,start_date,end_date) values ('녹색지대',CURDATE(),CURDATE());
+insert into events (name,start_date,end_date,location) values ('녹색지대',CURDATE(),CURDATE(),'서울 광진구 능동로 120 건국대학교 노천극장');
 insert into shows (name,start_date,end_date,ticketing_date,total_ticket_count,location)
 values ('DAY 1',CURDATE(),CURDATE(),CURDATE(),0,'서울 광진구 능동로 120 건국대학교 노천극장'),
        ('DAY 2',CURDATE()+1,CURDATE()+1,CURDATE()+1,0,'서울 광진구 능동로 120 건국대학교 노천극장'),

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -20,7 +20,9 @@ public class AuthConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
                 .excludePathPatterns("/api/v1/dev/**")
-                .excludePathPatterns("/api/v1/auth/**","/api/v1/users/register")
+                .excludePathPatterns("/api/v1/auth/**")
+                .excludePathPatterns("/api/v1/users/register")
+                .excludePathPatterns("/api/v1/universities/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error");
     }
 

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -22,7 +22,8 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api/v1/dev/**")
                 .excludePathPatterns("/api/v1/auth/**")
                 .excludePathPatterns("/api/v1/users/register")
-                .excludePathPatterns("/api/v1/universities/**")
+                .excludePathPatterns("/api/v1/universities","/api/v1/universities/{id}/event")
+                .excludePathPatterns("/api/v1/events/{id}/shows")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error");
     }
 

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -23,7 +23,6 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api/v1/auth/**")
                 .excludePathPatterns("/api/v1/users/register")
                 .excludePathPatterns("/api/v1/universities","/api/v1/universities/{id}/event")
-                .excludePathPatterns("/api/v1/events/{id}/shows")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error");
     }
 

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(registry -> registry
                         .requestMatchers("/api/v1/auth").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/universities/**").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry
                         .requestMatchers("/api/v1/dev/token").permitAll()

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
@@ -89,6 +89,14 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/universities/**").permitAll()
+                        .requestMatchers("/api/v1/events/{id}/shows").permitAll()
+                )
+                .authorizeHttpRequests(registry -> registry
+                        .requestMatchers("/api/v1/universities").permitAll()
+                        .requestMatchers("/api/v1/universities/{id}/event").permitAll()
+                )
+                .authorizeHttpRequests(registry -> registry
+                        .requestMatchers("/api/v1/events/{id}/shows").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry
                         .requestMatchers("/api/v1/dev/token").permitAll()

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
@@ -96,9 +96,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/universities/{id}/event").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry
-                        .requestMatchers("/api/v1/events/{id}/shows").permitAll()
-                )
-                .authorizeHttpRequests(registry -> registry
                         .requestMatchers("/api/v1/dev/token").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry

--- a/domain/event-domain/src/main/java/com/uket/domain/event/dto/ShowDto.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/dto/ShowDto.java
@@ -1,0 +1,29 @@
+package com.uket.domain.event.dto;
+
+import com.uket.domain.event.entity.Shows;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ShowDto(
+        Long id,
+        String name,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        LocalDateTime ticketingDate,
+        Integer totalTicketCount,
+        String location
+) {
+
+    public static ShowDto from(Shows show) {
+        return ShowDto.builder()
+                .id(show.getId())
+                .name(show.getName())
+                .startDate(show.getStartDate())
+                .endDate(show.getEndDate())
+                .ticketingDate(show.getTicketingDate())
+                .totalTicketCount(show.getTotalTicketCount())
+                .location(show.getLocation())
+                .build();
+    }
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
@@ -36,6 +36,7 @@ public class Events extends BaseEntity {
     private String name;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String location;
 
     public void updateUniversity(University university) {
         this.university = university;

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Shows.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Shows.java
@@ -1,0 +1,40 @@
+package com.uket.domain.event.entity;
+
+import com.uket.domain.core.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Shows extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "show_id")
+    private Long id;
+
+    private String name;
+    private LocalDate date;
+    private LocalDateTime ticketingDate;
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Events event;
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Shows.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Shows.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,8 +29,10 @@ public class Shows extends BaseEntity {
     private Long id;
 
     private String name;
-    private LocalDate date;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private LocalDateTime ticketingDate;
+    private Integer totalTicketCount;
     private String location;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/domain/event-domain/src/main/java/com/uket/domain/event/repository/ShowRepository.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/repository/ShowRepository.java
@@ -1,8 +1,11 @@
 package com.uket.domain.event.repository;
 
+import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.entity.Shows;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShowRepository extends JpaRepository<Shows, Long> {
 
+    List<Shows> findByEvent(Events event);
 }

--- a/domain/event-domain/src/main/java/com/uket/domain/event/repository/ShowRepository.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/repository/ShowRepository.java
@@ -1,0 +1,8 @@
+package com.uket.domain.event.repository;
+
+import com.uket.domain.event.entity.Shows;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShowRepository extends JpaRepository<Shows, Long> {
+
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -19,4 +19,9 @@ public class EventService {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(ErrorCode.NOT_FOUND_EVENT));
     }
+
+    public String getUniversityName(Long eventId) {
+        Events event = findById(eventId);
+        return event.getUniversity().getName();
+    }
 }

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -4,6 +4,8 @@ import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.exception.EventException;
 import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.exception.UniversityException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,11 @@ public class EventService {
 
     public String getUniversityName(Long eventId) {
         Events event = findById(eventId);
-        return event.getUniversity().getName();
+        University university = event.getUniversity();
+
+        if (university == null) {
+            throw new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY);
+        }
+        return university.getName();
     }
 }

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/ShowService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/ShowService.java
@@ -1,5 +1,10 @@
 package com.uket.domain.event.service;
 
+import com.uket.domain.event.dto.ShowDto;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.entity.Shows;
+import com.uket.domain.event.repository.ShowRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ShowService {
 
+    private final ShowRepository showRepository;
+
+    public List<ShowDto> findByEvent(Events event) {
+        List<Shows> shows = showRepository.findByEvent(event);
+
+        return shows.stream().map(ShowDto::from).toList();
+    }
 }

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/ShowService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/ShowService.java
@@ -1,0 +1,12 @@
+package com.uket.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShowService {
+
+}

--- a/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
+++ b/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
@@ -1,13 +1,18 @@
 package com.uket.domain.event.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.exception.EventException;
 import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.exception.UniversityException;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,5 +36,36 @@ class EventServiceTest {
         assertThatThrownBy(() -> eventService.findById(1L))
                 .isInstanceOf(EventException.class)
                 .hasMessage(ErrorCode.NOT_FOUND_EVENT.getMessage());
+    }
+
+    @Test
+    void 축제가_포함된_대학의_이름을_반환할_수_있다() {
+        University university = University.builder()
+                .name("건국대학교")
+                .build();
+        Events event = Events.builder()
+                .id(1L)
+                .university(university)
+                .build();
+
+        when(eventRepository.findById(any())).thenReturn(Optional.ofNullable(event));
+
+        String universityName = eventService.getUniversityName(event.getId());
+        assertThat(universityName).isEqualTo(university.getName());
+    }
+
+    @Test
+    void 축제가_대학에_속해있지_않다면_예외를_반환한다() {
+        //TODO
+        Events event = Events.builder()
+                .id(1L)
+                .build();
+
+        when(eventRepository.findById(any())).thenReturn(Optional.ofNullable(event));
+
+        Long eventId = event.getId();
+        assertThatThrownBy(() -> eventService.getUniversityName(eventId))
+                .isInstanceOf(UniversityException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_UNIVERSITY.getMessage());
     }
 }

--- a/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
+++ b/domain/event-domain/src/test/java/com/uket/domain/event/service/EventServiceTest.java
@@ -12,7 +12,6 @@ import com.uket.domain.event.repository.EventRepository;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.exception.UniversityException;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -56,7 +55,6 @@ class EventServiceTest {
 
     @Test
     void 축제가_대학에_속해있지_않다면_예외를_반환한다() {
-        //TODO
         Events event = Events.builder()
                 .id(1L)
                 .build();

--- a/domain/event-domain/src/test/java/com/uket/domain/event/service/ShowServiceTest.java
+++ b/domain/event-domain/src/test/java/com/uket/domain/event/service/ShowServiceTest.java
@@ -1,0 +1,51 @@
+package com.uket.domain.event.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.uket.domain.event.dto.ShowDto;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.entity.Shows;
+import com.uket.domain.event.repository.ShowRepository;
+import com.uket.domain.university.entity.University;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ShowServiceTest {
+
+    @InjectMocks
+    ShowService showService;
+
+    @Mock
+    ShowRepository showRepository;
+
+    @Test
+    void 공연을_조회할_수_있다() {
+        University university = University.builder().id(1L).name("건국대학교").build();
+
+        Events event = Events.builder().id(1L).university(university).build();
+
+        Shows show = Shows.builder()
+                .id(1L)
+                .name("DAY1")
+                .startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now())
+                .ticketingDate(LocalDateTime.now())
+                .location("자양동")
+                .event(event)
+                .build();
+
+        when(showRepository.findByEvent(any())).thenReturn(List.of(show));
+
+        Assertions.assertThat(showService.findByEvent(event))
+                .hasSize(1)
+                .contains(ShowDto.from(show));
+    }
+}


### PR DESCRIPTION
# 📌 개요
- 축제 별 공연을 조회할 수 있는 기능을 추가했습니다.
- 스토리보드 상에서 2-2 티켓 예매에서 사용할 API입니다.

# 💻 작업사항
- [x] 공연 도메인 기본 세팅
- [x] 축제 별 공연 조회 기능 추가

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- 응답으로 더 필요한 부분인 있는지 확인 부탁드립니다.
