### PR TITLE
[SVR-21] infra: Slack 에러 로깅 로직 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | Framework | Spring boot 3.2.4              |
 | ORM | Spring Data JPA with Querydsl  |
 | Build Tool | Gradle 8.4            |
-| Database | h2 2.2.224, MySQL 8.2.0, redis |
+| Database | MySQL 8.2.0, redis |
 | API Docs | SpringDoc Swagger 3            |
 | Test | JUnit 5                        |
 
@@ -26,4 +26,5 @@
 | JWT_SECRET_KEY       | JWT 토큰 시그티처 키 값           |
 | DEV_MYSQL_USERNAME   | 개발 서버 MySQL 사용자 명         |
 | DEV_MYSQL_PASSWORD   | 개발 서버 MySQL 비밀번호          |
+| SLACK_WEBHOOK_URL    | 에러 로깅을 위한 슬랙 Webhook url  |
 

--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation project(":domain:university-domain")
 	implementation project(":domain:event-domain")
 	implementation project(":modules:jwt-provider")
+	implementation project(":modules:slack")
 }
 
 tasks.named('test') {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/handler/WebExceptionHandler.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/handler/WebExceptionHandler.java
@@ -5,6 +5,7 @@ import com.uket.core.exception.BaseException;
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.auth.exception.AuthException;
 import com.uket.domain.user.exception.UserException;
+import com.uket.modules.slack.dto.ErrorReportDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.security.InvalidParameterException;
 import java.util.Enumeration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -28,6 +30,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RequiredArgsConstructor
 @RestControllerAdvice
 public class WebExceptionHandler {
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> unKnownException(HttpServletRequest request,
@@ -85,6 +89,8 @@ public class WebExceptionHandler {
             .append(getStackTraceAsString(exception));
 
         log.error("[UnhandledException] {} \n", dump);
+
+        eventPublisher.publishEvent(new ErrorReportDto(exception.getMessage(), dump.toString()));
         return ResponseEntity
             .internalServerError()
             .body(ErrorResponse.of(ErrorCode.UNKNOWN_SERVER_ERROR));

--- a/application/ticket-app-api/src/main/resources/application.yml
+++ b/application/ticket-app-api/src/main/resources/application.yml
@@ -34,6 +34,9 @@ app:
     user-info-uri: https://www.googleapis.com/oauth2/v1/userinfo
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
+  slack:
+    webhook:
+      url: ${SLACK_WEBHOOK_URL}
 ---
 
 spring:

--- a/application/ticket-app-api/src/test/resources/application.yml
+++ b/application/ticket-app-api/src/test/resources/application.yml
@@ -37,6 +37,9 @@ app:
     expiration:
       access-token-expiration: 3_600_000
       refresh-token-expiration: 7_200_000
+  slack:
+    webhook:
+      url: testestest
 
 
 

--- a/modules/slack/build.gradle
+++ b/modules/slack/build.gradle
@@ -1,0 +1,19 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'com.slack.api:slack-api-client:1.39.0'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.named('bootJar') {
+    enabled = false
+}
+
+tasks.named('jar') {
+    enabled = true
+}

--- a/modules/slack/src/main/java/com/uket/modules/slack/ApplicationListener.java
+++ b/modules/slack/src/main/java/com/uket/modules/slack/ApplicationListener.java
@@ -1,0 +1,57 @@
+package com.uket.modules.slack;
+
+import com.uket.modules.slack.dto.ErrorReportDto;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ApplicationListener {
+
+    private final SlackGateway slackGateway;
+    private final Environment environment;
+
+    private boolean isLocalProfile() {
+        List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+        return activeProfiles.contains("local");
+    }
+
+    @Async
+    @EventListener
+    public void onErrorReport(ErrorReportDto errorReportDto) {
+        if (isLocalProfile()) {
+            return;
+        }
+
+        String errorMessage = errorReportDto.errorMessage() == null ? "알 수 없는 에러" : errorReportDto.errorMessage();
+        SlackGateway.SlackBotDto dto = SlackGateway.SlackBotDto.builder()
+                .attachments(List.of(
+                        SlackGateway.SlackBotAttachmentDto.builder()
+                                .authorName("uket-server")
+                                .color("#ff2400")
+                                .title("백엔드 서비스 에러 리포트")
+                                .text("백엔드 서버에서 핸들링되지 않은 오류가 발생하였습니다")
+                                .fields(List.of(
+                                        SlackGateway.SlackBotFieldDto.builder()
+                                                .title("에러 메시지")
+                                                .value(errorMessage)
+                                                .shortField(false)
+                                                .build(),
+                                        SlackGateway.SlackBotFieldDto.builder()
+                                                .title("에러 페이로드")
+                                                .value(errorReportDto.payload())
+                                                .shortField(false)
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        slackGateway.sendErrorMessage(dto);
+    }
+}

--- a/modules/slack/src/main/java/com/uket/modules/slack/SlackGateway.java
+++ b/modules/slack/src/main/java/com/uket/modules/slack/SlackGateway.java
@@ -1,0 +1,71 @@
+package com.uket.modules.slack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class SlackGateway {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.slack.webhook.url}")
+    private String url;
+
+    @SneakyThrows
+    public void sendErrorMessage(SlackBotDto dto) {
+        String body = objectMapper.writeValueAsString(dto);
+        RestTemplate restTemplate = new RestTemplate();
+        RequestEntity<String> requestEntity = RequestEntity
+                .post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body);
+
+        restTemplate.exchange(requestEntity, Void.class);
+    }
+
+    @Builder
+    public record SlackBotDto (
+        @JsonProperty("attachments")
+        List<SlackBotAttachmentDto> attachments
+    ){
+
+    }
+
+    @Builder
+    public record SlackBotAttachmentDto (
+        @JsonProperty("color")
+        String color,
+        @JsonProperty("author_name")
+        String authorName,
+        @JsonProperty("title")
+        String title,
+        @JsonProperty("text")
+        String text,
+        @JsonProperty("fields")
+        List<SlackBotFieldDto> fields
+    ){
+
+    }
+
+    @Builder
+    public record SlackBotFieldDto (
+        @JsonProperty("title")
+        String title,
+        @JsonProperty("value")
+        String value,
+        @JsonProperty("short")
+        boolean shortField
+    ){
+
+    }
+}

--- a/modules/slack/src/main/java/com/uket/modules/slack/dto/ErrorReportDto.java
+++ b/modules/slack/src/main/java/com/uket/modules/slack/dto/ErrorReportDto.java
@@ -1,0 +1,7 @@
+package com.uket.modules.slack.dto;
+
+public record ErrorReportDto(
+        String errorMessage,
+        String payload
+) {
+}


### PR DESCRIPTION
# 📌 개요
- 핸들링 되지 않은 에러를 처리하기 위해 Slack으로 에러 메세지를 받도록 설정했습니다.

# 💻 작업사항
- [x] slack 에러 로깅 로직 추가

# ❌ 주의사항
- SLACK_WEBHOOK_URL 환경변수가 추가되었습니다. 필요시 서버측에 문의주세요

# 💡 코드 리뷰 요청사항
- N/A
