### PR TITLE
[SVR-8] feat: 학교 메일 인증 로직 추가

### DIFF
--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	//spring-data

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/config/EmailConfig.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/config/EmailConfig.java
@@ -1,0 +1,43 @@
+package com.uket.app.ticket.api.config;
+
+import com.uket.app.ticket.api.properties.EmailProperties;
+import com.uket.app.ticket.api.properties.SmtpProperties;
+import java.util.Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+
+    private final EmailProperties emailProperties;
+    private final SmtpProperties smtpProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(emailProperties.host());
+        mailSender.setPort(emailProperties.port());
+        mailSender.setUsername(emailProperties.username());
+        mailSender.setPassword(emailProperties.password());
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", smtpProperties.auth());
+        properties.put("mail.smtp.starttls.enable", smtpProperties.starttls().enable());
+        properties.put("mail.smtp.starttls.required", smtpProperties.starttls().required());
+        properties.put("mail.smtp.connectiontimeout", smtpProperties.connectiontimeout());
+        properties.put("mail.smtp.timeout", smtpProperties.timeout());
+        properties.put("mail.smtp.writetimeout", smtpProperties.writetimeout());
+
+        return properties;
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
@@ -1,11 +1,9 @@
 package com.uket.app.ticket.api.controller;
 
-import com.uket.app.ticket.api.dto.request.EmailRequest;
-import com.uket.domain.auth.config.userid.LoginUserId;
+import com.uket.app.ticket.api.dto.request.AuthEmailRequest;
+import com.uket.app.ticket.api.dto.response.AuthEmailResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -14,22 +12,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "티켓 API", description = "티켓 관련 API")
+@Tag(name = "이메일 API", description = "이메일 관련 API")
 @RestController
 @RequestMapping("/api/v1/email")
-@SecurityRequirement(name = "JWT")
 @ApiResponse(responseCode = "200", description = "OK")
 public interface EmailApi {
 
     @PostMapping("/send")
     @Operation(summary = "이메일 전송 요청 API", description = "이메일 인증 요청을 할 수 있습니다.")
-    ResponseEntity<?> sendEmail(
-            @Parameter(hidden = true)
-            @LoginUserId
-            Long userId,
-
+    ResponseEntity<AuthEmailResponse> sendEmail(
             @Valid
             @RequestBody
-            EmailRequest request
+            AuthEmailRequest request
     );
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
@@ -1,5 +1,6 @@
 package com.uket.app.ticket.api.controller;
 
+import com.uket.app.ticket.api.dto.request.AuthCodeRequest;
 import com.uket.app.ticket.api.dto.request.AuthEmailRequest;
 import com.uket.app.ticket.api.dto.response.AuthEmailResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,5 +25,13 @@ public interface EmailApi {
             @Valid
             @RequestBody
             AuthEmailRequest request
+    );
+
+    @PostMapping("/verify")
+    @Operation(summary = "인증 코드 확인 API", description = "이메일 인증 코드를 확인 할 수 있습니다.")
+    ResponseEntity<Void> verifyEmail(
+            @Valid
+            @RequestBody
+            AuthCodeRequest request
     );
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EmailApi.java
@@ -1,0 +1,35 @@
+package com.uket.app.ticket.api.controller;
+
+import com.uket.app.ticket.api.dto.request.EmailRequest;
+import com.uket.domain.auth.config.userid.LoginUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "티켓 API", description = "티켓 관련 API")
+@RestController
+@RequestMapping("/api/v1/email")
+@SecurityRequirement(name = "JWT")
+@ApiResponse(responseCode = "200", description = "OK")
+public interface EmailApi {
+
+    @PostMapping("/send")
+    @Operation(summary = "이메일 전송 요청 API", description = "이메일 인증 요청을 할 수 있습니다.")
+    ResponseEntity<?> sendEmail(
+            @Parameter(hidden = true)
+            @LoginUserId
+            Long userId,
+
+            @Valid
+            @RequestBody
+            EmailRequest request
+    );
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
@@ -1,7 +1,10 @@
 package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.EmailApi;
-import com.uket.app.ticket.api.dto.request.EmailRequest;
+import com.uket.app.ticket.api.dto.request.AuthEmailRequest;
+import com.uket.app.ticket.api.dto.response.AuthEmailResponse;
+import com.uket.app.ticket.api.properties.EmailProperties;
+import com.uket.app.ticket.api.service.UserAuthEmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -10,8 +13,16 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class EmailController implements EmailApi {
 
+    private final EmailProperties emailProperties;
+    private final UserAuthEmailService userAuthEmailService;
+
     @Override
-    public ResponseEntity<?> sendEmail(Long userId, EmailRequest request) {
-        return null;
+    public ResponseEntity<AuthEmailResponse> sendEmail(AuthEmailRequest request) {
+        String email = request.email();
+        Long expiration = emailProperties.properties().authCodeExpirationMillis();
+
+        userAuthEmailService.sendAuthEmail(email);
+
+        return ResponseEntity.ok(AuthEmailResponse.of(email, expiration));
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
@@ -19,9 +19,10 @@ public class EmailController implements EmailApi {
     @Override
     public ResponseEntity<AuthEmailResponse> sendEmail(AuthEmailRequest request) {
         String email = request.email();
+        Long universityId = request.universityId();
         Long expiration = emailProperties.properties().authCodeExpirationMillis();
 
-        userAuthEmailService.sendAuthEmail(email);
+        userAuthEmailService.sendAuthEmail(email, universityId);
 
         return ResponseEntity.ok(AuthEmailResponse.of(email, expiration));
     }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
@@ -1,0 +1,17 @@
+package com.uket.app.ticket.api.controller.impl;
+
+import com.uket.app.ticket.api.controller.EmailApi;
+import com.uket.app.ticket.api.dto.request.EmailRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class EmailController implements EmailApi {
+
+    @Override
+    public ResponseEntity<?> sendEmail(Long userId, EmailRequest request) {
+        return null;
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EmailController.java
@@ -1,6 +1,7 @@
 package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.EmailApi;
+import com.uket.app.ticket.api.dto.request.AuthCodeRequest;
 import com.uket.app.ticket.api.dto.request.AuthEmailRequest;
 import com.uket.app.ticket.api.dto.response.AuthEmailResponse;
 import com.uket.app.ticket.api.properties.EmailProperties;
@@ -25,5 +26,13 @@ public class EmailController implements EmailApi {
         userAuthEmailService.sendAuthEmail(email, universityId);
 
         return ResponseEntity.ok(AuthEmailResponse.of(email, expiration));
+    }
+
+    @Override
+    public ResponseEntity<Void> verifyEmail(AuthCodeRequest request) {
+
+        userAuthEmailService.verifyAuthEmail(request.email(), request.universityId(), request.authCode());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthCodeRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthCodeRequest.java
@@ -1,0 +1,12 @@
+package com.uket.app.ticket.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record AuthCodeRequest(
+        @Email
+        String email,
+        Long universityId,
+        String authCode
+) {
+
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthEmailRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthEmailRequest.java
@@ -4,7 +4,9 @@ import jakarta.validation.constraints.Email;
 
 public record AuthEmailRequest(
         @Email
-        String email
+        String email,
+
+        Long universityId
 ) {
 
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthEmailRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/AuthEmailRequest.java
@@ -2,7 +2,7 @@ package com.uket.app.ticket.api.dto.request;
 
 import jakarta.validation.constraints.Email;
 
-public record EmailRequest(
+public record AuthEmailRequest(
         @Email
         String email
 ) {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/EmailRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/EmailRequest.java
@@ -1,0 +1,10 @@
+package com.uket.app.ticket.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record EmailRequest(
+        @Email
+        String email
+) {
+
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AuthEmailResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AuthEmailResponse.java
@@ -1,0 +1,12 @@
+package com.uket.app.ticket.api.dto.response;
+
+public record AuthEmailResponse(
+        Boolean success,
+        String email,
+        Long expiration
+) {
+
+    public static AuthEmailResponse of(String email, Long expiration) {
+        return new AuthEmailResponse(true, email, expiration);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/properties/EmailProperties.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/properties/EmailProperties.java
@@ -1,0 +1,22 @@
+package com.uket.app.ticket.api.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = "spring.mail")
+@ConfigurationPropertiesBinding
+public record EmailProperties(
+        String host,
+        Integer port,
+        String username,
+        String password,
+        @NestedConfigurationProperty EmailDetailProperties properties
+) {
+    @ConfigurationPropertiesBinding
+    public record EmailDetailProperties(
+            Long authCodeExpirationMillis
+    ) {
+
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/properties/SmtpProperties.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/properties/SmtpProperties.java
@@ -1,0 +1,24 @@
+package com.uket.app.ticket.api.properties;
+
+import com.uket.app.ticket.api.properties.EmailProperties.EmailDetailProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = "spring.mail.properties.mail.smtp")
+@ConfigurationPropertiesBinding
+public record SmtpProperties(
+        Boolean auth,
+        Long connectiontimeout,
+        Long timeout,
+        Long writetimeout,
+        @NestedConfigurationProperty StarttlsProperties starttls
+) {
+    @ConfigurationPropertiesBinding
+    public record StarttlsProperties(
+            Boolean enable,
+            Boolean required
+    ) {
+
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/MailService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/MailService.java
@@ -1,0 +1,35 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailService {
+
+        private final JavaMailSender javaMailSender;
+
+        public void sendEmail(String to, String subject, String text) {
+            SimpleMailMessage emailForm = createEmailForm(to, subject, text);
+            try {
+                javaMailSender.send(emailForm);
+            } catch (RuntimeException e) {
+                throw new BaseException(ErrorCode.UNABLE_TO_SEND_EMAIL);
+            }
+        }
+
+    private SimpleMailMessage createEmailForm(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+
+        return message;
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
@@ -2,6 +2,7 @@ package com.uket.app.ticket.api.service;
 
 import com.uket.app.ticket.api.properties.EmailProperties;
 import com.uket.app.ticket.api.util.RandomCodeGenerator;
+import com.uket.domain.university.service.UniversityService;
 import com.uket.domain.user.service.UserService;
 import com.uket.modules.redis.service.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -12,15 +13,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserAuthEmailService {
+
     private static final String AUTH_CODE_PREFIX = "AuthCode:";
 
     private final MailService mailService;
     private final UserService userService;
+    private final UniversityService universityService;
+
     private final EmailProperties emailProperties;
     private final RedisUtil redisUtil;
 
-    public void sendAuthEmail(String email) {
-        userService.checkDuplicateEmail(email);
+    public void sendAuthEmail(String email, Long universityId) {
+        validateEmail(email, universityId);
 
         String subject = "Uket 회원가입 인증 코드입니다.";
         String authCode = RandomCodeGenerator.generateRandomCode();
@@ -30,4 +34,8 @@ public class UserAuthEmailService {
         redisUtil.setDataExpire(AUTH_CODE_PREFIX + email, authCode, authCodeExpirationMillis);
     }
 
+    private void validateEmail(String email, Long universityId) {
+        userService.checkDuplicateEmail(email);
+        universityService.checkEmailPrefix(email, universityId);
+    }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
@@ -1,0 +1,33 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.app.ticket.api.properties.EmailProperties;
+import com.uket.app.ticket.api.util.RandomCodeGenerator;
+import com.uket.domain.user.service.UserService;
+import com.uket.modules.redis.service.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserAuthEmailService {
+    private static final String AUTH_CODE_PREFIX = "AuthCode:";
+
+    private final MailService mailService;
+    private final UserService userService;
+    private final EmailProperties emailProperties;
+    private final RedisUtil redisUtil;
+
+    public void sendAuthEmail(String email) {
+        userService.checkDuplicateEmail(email);
+
+        String subject = "Uket 회원가입 인증 코드입니다.";
+        String authCode = RandomCodeGenerator.generateRandomCode();
+        Long authCodeExpirationMillis = emailProperties.properties().authCodeExpirationMillis();
+
+        mailService.sendEmail(email, subject, authCode);
+        redisUtil.setDataExpire(AUTH_CODE_PREFIX + email, authCode, authCodeExpirationMillis);
+    }
+
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/UserAuthEmailService.java
@@ -2,6 +2,8 @@ package com.uket.app.ticket.api.service;
 
 import com.uket.app.ticket.api.properties.EmailProperties;
 import com.uket.app.ticket.api.util.RandomCodeGenerator;
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.auth.exception.AuthException;
 import com.uket.domain.university.service.UniversityService;
 import com.uket.domain.user.service.UserService;
 import com.uket.modules.redis.service.RedisUtil;
@@ -32,6 +34,17 @@ public class UserAuthEmailService {
 
         mailService.sendEmail(email, subject, authCode);
         redisUtil.setDataExpire(AUTH_CODE_PREFIX + email, authCode, authCodeExpirationMillis);
+    }
+
+    public void verifyAuthEmail(String email, Long universityId, String authCode) {
+        validateEmail(email, universityId);
+
+        String savedAuthCode = redisUtil.getData(AUTH_CODE_PREFIX + email)
+                .orElseThrow(() -> new AuthException(ErrorCode.INVALID_AUTH_CODE));
+
+        if (!authCode.equals(savedAuthCode)) {
+            throw new AuthException(ErrorCode.NOT_MATCHED_AUTH_CODE);
+        }
     }
 
     private void validateEmail(String email, Long universityId) {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/RandomCodeGenerator.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/RandomCodeGenerator.java
@@ -1,0 +1,15 @@
+package com.uket.app.ticket.api.util;
+
+import java.util.Random;
+
+public class RandomCodeGenerator {
+
+    private static final Random random = new Random();
+    private static final int CODE_LENGTH = 5;
+    private static final int MIN = (int) Math.pow(10, CODE_LENGTH);
+    private static final int MAX = 9 * MIN;
+
+    public static String generateRandomCode() {
+        return Integer.toString(random.nextInt(MAX) + MIN);
+    }
+}

--- a/application/ticket-app-api/src/main/resources/application.yml
+++ b/application/ticket-app-api/src/main/resources/application.yml
@@ -17,6 +17,22 @@ spring:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
         bucket: ${AWS_S3_BUCKET}
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 1800000
 
 springdoc:
   packages-to-scan: com.uket

--- a/application/ticket-app-api/src/test/resources/application.yml
+++ b/application/ticket-app-api/src/test/resources/application.yml
@@ -36,6 +36,22 @@ spring:
         access-key: adsfdasfdsa
         secret-key: adfsafdsa
         bucket: adfasfdsaf
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: abc1234@gmail.com
+    password: dfsfdsfdsfdsf
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 1800000
 
 app:
   kakao:

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -10,59 +10,61 @@ public enum ErrorCode {
     /**
      * Common Errors
      */
-    UNKNOWN_SERVER_ERROR(500,"CM0001", "일시적으로 접속이 원활하지 않습니다. 서버 팀에 문의 부탁드립니다."),
-    INVALID_INPUT_VALUE(400,"CM0002", "유효하지 않은 입력입니다."),
-    INVALID_DATE(400,"CM0003", "유효하지 않은 연 또는 월입니다."),
-    METHOD_NOT_ALLOWED(405,"CM0004", "허가되지 않은 메서드입니다."),
-    IO_ERROR(500,"CM0005", "I/O 관련 에러입니다. 서버 팀에 문의 부탁드립니다."),
+    UNKNOWN_SERVER_ERROR(500, "CM0001", "일시적으로 접속이 원활하지 않습니다. 서버 팀에 문의 부탁드립니다."),
+    INVALID_INPUT_VALUE(400, "CM0002", "유효하지 않은 입력입니다."),
+    INVALID_DATE(400, "CM0003", "유효하지 않은 연 또는 월입니다."),
+    METHOD_NOT_ALLOWED(405, "CM0004", "허가되지 않은 메서드입니다."),
+    IO_ERROR(500, "CM0005", "I/O 관련 에러입니다. 서버 팀에 문의 부탁드립니다."),
 
     /**
      * Auth Related Errors
      */
-    NOT_MATCH_CATEGORY(400,"AU0001", "올바르지 않은 유형의 토큰입니다."),
-    FAIL_REQUEST_TO_OAUTH2(400,"AU0002", "OAuth2 요청이 실패했습니다."),
-    AUTHENTICATION_FAILED(401,"AU0003", "인증에 실패하였습니다."),
-    TOKEN_AUTHENTICATION_FAILED(401,"AU0004", "토큰 인증에 실패하였습니다."),
-    INVALID_TOKEN(401,"AU0005", "유효하지 않은 토큰입니다."),
-    INVALID_PLATFORM(400,"AU0006", "유효하지 않은 플랫폼입니다."),
-    AUTHORIZATION_FAILED(403,"AU0007", "접근 권한이 없습니다."),
-    TOKEN_EXPIRED(403,"AU0008", "만료된 토큰입니다."),
-    TOKEN_NOT_EXPIRED(403,"AU0009", "아직 토큰이 만료되지 않았습니다."),
+    NOT_MATCH_CATEGORY(400, "AU0001", "올바르지 않은 유형의 토큰입니다."),
+    FAIL_REQUEST_TO_OAUTH2(400, "AU0002", "OAuth2 요청이 실패했습니다."),
+    AUTHENTICATION_FAILED(401, "AU0003", "인증에 실패하였습니다."),
+    TOKEN_AUTHENTICATION_FAILED(401, "AU0004", "토큰 인증에 실패하였습니다."),
+    INVALID_TOKEN(401, "AU0005", "유효하지 않은 토큰입니다."),
+    INVALID_PLATFORM(400, "AU0006", "유효하지 않은 플랫폼입니다."),
+    AUTHORIZATION_FAILED(403, "AU0007", "접근 권한이 없습니다."),
+    TOKEN_EXPIRED(403, "AU0008", "만료된 토큰입니다."),
+    TOKEN_NOT_EXPIRED(403, "AU0009", "아직 토큰이 만료되지 않았습니다."),
     UNABLE_TO_SEND_EMAIL(400, "AU0010", "이메일 전송에 실패했습니다."),
+    INVALID_AUTH_CODE(400, "AU0011", "유효하지 않은 인증 코드입니다."),
+    NOT_MATCHED_AUTH_CODE(400, "AU0012", "올바르지 않은 인증 코드입니다."),
 
     /**
      * User Errors
      */
-    NOT_FOUND_USER(404,"US0001", "해당 사용자를 찾을 수 없습니다."),
-    ALREADY_EXIST_USER(409,"US0002", "이미 가입된 사용자입니다."),
-    NOT_REGISTERED_USER(400,"US0003", "가입되지 않은 사용자입니다. 회원가입 후 이용해주세요"),
-    NOT_FOUND_USER_DETAIL(404,"US0004", "해당 사용자 세부정보를 찾을 수 없습니다."),
+    NOT_FOUND_USER(404, "US0001", "해당 사용자를 찾을 수 없습니다."),
+    ALREADY_EXIST_USER(409, "US0002", "이미 가입된 사용자입니다."),
+    NOT_REGISTERED_USER(400, "US0003", "가입되지 않은 사용자입니다. 회원가입 후 이용해주세요"),
+    NOT_FOUND_USER_DETAIL(404, "US0004", "해당 사용자 세부정보를 찾을 수 없습니다."),
 
     /**
      * University Errors
      */
-    NOT_FOUND_UNIVERSITY(404,"UN0001", "해당 대학을 찾을 수 없습니다."),
-    NOT_MATCH_UNIVERSITY_EMAIL(400,"UN0002", "대학 이메일 정보가 잘못되었습니다."),
+    NOT_FOUND_UNIVERSITY(404, "UN0001", "해당 대학을 찾을 수 없습니다."),
+    NOT_MATCH_UNIVERSITY_EMAIL(400, "UN0002", "대학 이메일 정보가 잘못되었습니다."),
 
     /**
      * Events Errors
      */
-    NOT_FOUND_EVENT(404,"EV0001", "해당 축제를 찾을 수 없습니다."),
-    NOT_FOUND_CURRENT_EVENT(404,"EV0002", "진행중인 축제를 찾을 수 없습니다."),
-    NOT_FOUND_SHOW(404,"EV0003", "해당 공연을 찾을 수 없습니다."),
-    NOT_FOUND_RESERVATION(404,"EV0004", "해당 예매 정보를 찾을 수 없습니다."),
+    NOT_FOUND_EVENT(404, "EV0001", "해당 축제를 찾을 수 없습니다."),
+    NOT_FOUND_CURRENT_EVENT(404, "EV0002", "진행중인 축제를 찾을 수 없습니다."),
+    NOT_FOUND_SHOW(404, "EV0003", "해당 공연을 찾을 수 없습니다."),
+    NOT_FOUND_RESERVATION(404, "EV0004", "해당 예매 정보를 찾을 수 없습니다."),
 
     /**
      * Ticket Errors
      */
-    FAIL_TO_GENERATE_QRCODE(500,"TI0001","QR CODE 생성을 실패했습니다."),
-    FAIL_TICKETING_COUNT(400,"TI0002","티켓 예매 가능 인원이 없습니다."),
-    ALREADY_EXIST_TICKET(400,"TI0003","이미 예약된 티켓입니다."),
-    INVALID_RESERVATION_USER_TYPE(400,"TI0004","예매가 불가능한 사용자 구분입니다."),
-    DUPLICATE_RESERVATION_OF_SAME_SHOW(400,"TI0005","해당 공연에 이미 예약이 되어있습니다."),
-    OVER_TIME_OF_POSSIBLE_TICKETING_TIME(400,"TI0006","예매 가능 시각이 지났습니다."),
-    NOT_READY_TICKETING(400,"TI0007","예매 시작 전입니다."),
-    INVALID_ACCESS_TICKET(400,"TI0008","해당 티켓을 소유하지 않은 사용자입니다.");
+    FAIL_TO_GENERATE_QRCODE(500, "TI0001", "QR CODE 생성을 실패했습니다."),
+    FAIL_TICKETING_COUNT(400, "TI0002", "티켓 예매 가능 인원이 없습니다."),
+    ALREADY_EXIST_TICKET(400, "TI0003", "이미 예약된 티켓입니다."),
+    INVALID_RESERVATION_USER_TYPE(400, "TI0004", "예매가 불가능한 사용자 구분입니다."),
+    DUPLICATE_RESERVATION_OF_SAME_SHOW(400, "TI0005", "해당 공연에 이미 예약이 되어있습니다."),
+    OVER_TIME_OF_POSSIBLE_TICKETING_TIME(400, "TI0006", "예매 가능 시각이 지났습니다."),
+    NOT_READY_TICKETING(400, "TI0007", "예매 시작 전입니다."),
+    INVALID_ACCESS_TICKET(400, "TI0008", "해당 티켓을 소유하지 않은 사용자입니다.");
 
     private final int status;
     private final String code;

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     AUTHORIZATION_FAILED(403,"AU0007", "접근 권한이 없습니다."),
     TOKEN_EXPIRED(403,"AU0008", "만료된 토큰입니다."),
     TOKEN_NOT_EXPIRED(403,"AU0009", "아직 토큰이 만료되지 않았습니다."),
+    UNABLE_TO_SEND_EMAIL(400, "AU0010", "이메일 전송에 실패했습니다."),
 
     /**
      * User Errors

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/AuthConfig.java
@@ -20,6 +20,7 @@ public class AuthConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
                 .excludePathPatterns("/api/v1/dev/**")
+                .excludePathPatterns("/api/v1/email/**")
                 .excludePathPatterns("/api/v1/auth/**")
                 .excludePathPatterns("/api/v1/users/register")
                 .excludePathPatterns("/api/v1/universities","/api/v1/universities/{id}/event")

--- a/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
+++ b/domain/auth-domain/src/main/java/com/uket/domain/auth/config/SecurityConfig.java
@@ -96,6 +96,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/universities/{id}/event").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry
+                        .requestMatchers("/api/v1/email/**").permitAll()
                         .requestMatchers("/api/v1/dev/token").permitAll()
                 )
                 .authorizeHttpRequests(registry -> registry

--- a/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/service/UniversityService.java
@@ -48,4 +48,13 @@ public class UniversityService {
         }
         return Optional.ofNullable(university.getCurrentEvent());
     }
+
+    public void checkEmailPrefix(String email, Long universityId) {
+        University university = universityRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityException(ErrorCode.NOT_FOUND_UNIVERSITY));
+
+        if (Boolean.TRUE.equals(isDefault(university)) || !email.endsWith(university.getEmailPostFix())) {
+            throw new UniversityException(ErrorCode.NOT_MATCH_UNIVERSITY_EMAIL);
+        }
+    }
 }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/repository/UserRepository.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<Users,Long> {
 
     Optional<Users> findByPlatformAndPlatformId(Platform platform, String platformId);
 
+    Boolean existsByEmail(String email);
+
 }

--- a/domain/user-domain/src/main/java/com/uket/domain/user/service/UserService.java
+++ b/domain/user-domain/src/main/java/com/uket/domain/user/service/UserService.java
@@ -63,4 +63,10 @@ public class UserService {
         userRepository.save(existUser);
         return existUser;
     }
+
+    public void checkDuplicateEmail(String email) {
+        if (Boolean.TRUE.equals(userRepository.existsByEmail(email))) {
+            throw new UserException(ErrorCode.ALREADY_EXIST_USER);
+        }
+    }
 }

--- a/modules/token-redis/src/main/java/com/uket/modules/redis/config/RedisConfig.java
+++ b/modules/token-redis/src/main/java/com/uket/modules/redis/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -40,5 +41,10 @@ public class RedisConfig {
         redisTemplate.setDefaultSerializer(new StringRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public ValueOperations<String,String> valueOperations(RedisTemplate<String, String> redisTemplate){
+        return redisTemplate.opsForValue();
     }
 }

--- a/modules/token-redis/src/main/java/com/uket/modules/redis/service/RedisUtil.java
+++ b/modules/token-redis/src/main/java/com/uket/modules/redis/service/RedisUtil.java
@@ -1,0 +1,28 @@
+package com.uket.modules.redis.service;
+
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final ValueOperations<String, String> valueOperations;
+
+    public void setDataExpire(String key, String value, Long duration) {
+        Duration expireDuration = Duration.ofMillis(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public Optional<String> getData(String key) {
+        String value = valueOperations.get(key);
+
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+}


### PR DESCRIPTION
# 📌 개요
- 학교 메일 인증 로직 추가했습니다.
<img width="218" alt="image" src="https://github.com/DCNJ-Uket/Uket-BE/assets/127181370/467f19f5-eae8-4fc3-9bf0-be0eb31804ee">

- 서버에서 가지고 있는 이메일 외에는 인증이 불가능 합니다.
  - 현재 건국대만 테스트 가능합니다.

# 💻 작업사항
- [x] 이메일 전송 로직 추가
- [x] 인증 코드 생성 로직 추가
- [x] 인증코드 검증 로직 추가

# ❌ 주의사항
- redis를 통해서 인증 코드를 관리합니다. (prefix -> AuthCode)
- 이메일 테스트를 위해 환경변수 적용이 필요합니다. 테스트 시 서버 측에 문의주세요
- 현재 새 이메일 계정을 생성하지는 않고 개인 이메일로 전송하고 있으니 유의해주세요
- 추후 회의 때, 이메일 내용 구성을 논의할 필요가 있을 것 같습니다. 현재는 인증 코드만 발송하고 있습니다.

# 💡 코드 리뷰 요청사항
- 이메일이 잘 전송되는지 확인해주세요
- 추가적으로 검증이 필요한 로직이 있는지 확인해주세요
