### PR TITLE
hotfix: 티켓 중복 검증 로직 삭제

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/TicketingService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/TicketingService.java
@@ -68,7 +68,6 @@ public class TicketingService {
         if (Boolean.FALSE.equals(ticketingValidator.validateStudentOfUniversity(user, university))) {
             ticketingValidator.validateReservationUserType(reservation);
         }
-        ticketingValidator.validateDuplicateReservationOfSameShow(user, reservation);
     }
 
     private CreateTicketDto generateCreateTicketDto(Users user, University university, Reservation reservation) {


### PR DESCRIPTION
# 📌 개요
- 

# 💻 작업사항
- 티켓 중복 로직으로인해 티켓을 취소할 경우 같은 시간대에 다시 예매를 할 수 없어 해당 로직 삭제 진행했습니다.

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
