### PR TITLE
[SVR-41] feat: 티켓 및 공연 시간대 Asia/Seoul로 설정

### DIFF
--- a/domain/event-domain/src/main/java/com/uket/domain/event/dto/ReservationDto.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/dto/ReservationDto.java
@@ -3,14 +3,16 @@ package com.uket.domain.event.dto;
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.enums.ReservationUserType;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import lombok.Builder;
 
 @Builder
 public record ReservationDto(
         Long id,
         ReservationUserType type,
-        LocalDateTime startTime,
-        LocalDateTime endTime,
+        ZonedDateTime startTime,
+        ZonedDateTime endTime,
         Integer reservedCount,
         Integer totalCount
 ) {
@@ -18,8 +20,8 @@ public record ReservationDto(
         return ReservationDto.builder()
                 .id(reservation.getId())
                 .type(reservation.getType())
-                .startTime(reservation.getStartTime())
-                .endTime(reservation.getEndTime())
+                .startTime(ZonedDateTime.of(reservation.getStartTime(), ZoneId.of("Asia/Seoul")))
+                .endTime(ZonedDateTime.of(reservation.getEndTime(), ZoneId.of("Asia/Seoul")))
                 .reservedCount(reservation.getReservedCount())
                 .totalCount(reservation.getTotalCount())
                 .build();

--- a/domain/event-domain/src/main/java/com/uket/domain/event/dto/ShowDto.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/dto/ShowDto.java
@@ -2,26 +2,30 @@ package com.uket.domain.event.dto;
 
 import com.uket.domain.event.entity.Shows;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import lombok.Builder;
 
 @Builder
 public record ShowDto(
         Long id,
         String name,
-        LocalDateTime startDate,
-        LocalDateTime endDate,
-        LocalDateTime ticketingDate,
+        ZonedDateTime startDate,
+        ZonedDateTime endDate,
+        ZonedDateTime ticketingDate,
         Integer totalTicketCount,
         String location
 ) {
 
     public static ShowDto from(Shows show) {
+        String zoneId = "Asia/Seoul";
+
         return ShowDto.builder()
                 .id(show.getId())
                 .name(show.getName())
-                .startDate(show.getStartDate())
-                .endDate(show.getEndDate())
-                .ticketingDate(show.getTicketingDate())
+                .startDate(ZonedDateTime.of(show.getStartDate(), ZoneId.of(zoneId)))
+                .endDate(ZonedDateTime.of(show.getEndDate(), ZoneId.of(zoneId)))
+                .ticketingDate(ZonedDateTime.of(show.getTicketingDate(), ZoneId.of(zoneId)))
                 .totalTicketCount(show.getTotalTicketCount())
                 .location(show.getLocation())
                 .build();

--- a/domain/event-domain/src/test/java/com/uket/domain/event/service/ShowServiceTest.java
+++ b/domain/event-domain/src/test/java/com/uket/domain/event/service/ShowServiceTest.java
@@ -5,10 +5,11 @@ import static org.mockito.Mockito.when;
 
 import com.uket.domain.event.dto.ShowDto;
 import com.uket.domain.event.entity.Events;
-import com.uket.domain.event.entity.Shows;
 import com.uket.domain.event.repository.ShowRepository;
 import com.uket.domain.university.entity.University;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -35,9 +36,9 @@ class ShowServiceTest {
         ShowDto show = ShowDto.builder()
                 .id(1L)
                 .name("DAY1")
-                .startDate(LocalDateTime.now())
-                .endDate(LocalDateTime.now())
-                .ticketingDate(LocalDateTime.now())
+                .startDate(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Asia/Seoul")))
+                .endDate(ZonedDateTime.of(LocalDateTime.now(),ZoneId.of("Asia/Seoul")))
+                .ticketingDate(ZonedDateTime.of(LocalDateTime.now(),ZoneId.of("Asia/Seoul")))
                 .location("자양동")
                 .totalTicketCount(1000)
                 .build();


### PR DESCRIPTION
# 📌 개요
- 티켓 및 공연 시간대 Asia/Seoul로 설정

# 💻 작업사항
- [x] 티켓 및 공연 시간대 Asia/Seoul로 설정

# ❌ 주의사항
- 배포한 후 테스트해봐야하는 사항이라 바로 합쳐보겠습니당

# 💡 코드 리뷰 요청사항
- 
