### PR TITLE
hotfix: test위해 ticket 중복 validation 삭제

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
@@ -25,7 +25,7 @@ public class TicketController implements TicketApi {
     @Override
     public ResponseEntity<TicketingResponse> ticketing(Long userId, TicketingRequest request) {
 
-        ticketingService.validateTicketing(userId, request.universityId(), request.reservationId());
+        //ticketingService.validateTicketing(userId, request.universityId(), request.reservationId());
         ticketingService.increaseReservedCount(request.reservationId());
 
         TicketDto ticket = ticketingService.ticketing(userId, request.universityId(), request.reservationId());

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -40,9 +40,11 @@ public class TicketService {
         Users user = createTicketDto.user();
         Reservation reservation = createTicketDto.reservation();
 
+        /*
         if(Boolean.TRUE.equals(ticketRepository.existsByUserAndReservationAndStatusNot(user, reservation, TicketStatus.RESERVATION_CANCEL))){
             throw new TicketException(ErrorCode.ALREADY_EXIST_TICKET);
         }
+         */
 
         Ticket ticket = Ticket.builder()
                 .user(user)


### PR DESCRIPTION
# 📌 개요
- 

# 💻 작업사항
- 부하테스트를 진행하기 위해 user 1명의 정보로 여러장의 티켓을 구매할 수 있도록 ticket 중복 validation 코드를 주석처리 해두었습니다.

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
