### PR TITLE
[SVR-46] 관리자 티켓 예매 내역 조회

### DIFF
--- a/application/admin-app-api/build.gradle
+++ b/application/admin-app-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(":domain:ticket-domain")
     implementation project(":domain:admin-auth-domain")
     implementation project(":domain:user-domain")
+    implementation project(":domain:event-domain")
 }
 
 tasks.named('test') {

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -13,9 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -88,8 +86,16 @@ public interface TicketApi {
     );
 
     @Operation(summary = "전체 티켓 페이지별 조회", description = "전체 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @GetMapping("/all")
+    @GetMapping("/search/all")
     ResponseEntity<CustomPageResponse<TicketResponse>> getAllTickets(
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
+
+    @Operation(summary = "티켓 상태로 티켓 페이지별 조회", description = "티켓 상태로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @GetMapping("/search/{ticketStatus}")
+    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByStatus(
+        @PathVariable("ticketStatus") TicketStatus ticketStatus,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
@@ -97,33 +103,26 @@ public interface TicketApi {
     /*
     @Operation(summary = "사용자 이름으로 티켓 조회", description = "사용자 이름으로 티켓을 조회합니다.")
     @GetMapping("/byUserName")
-    ResponseEntity<Page<TicketResponse>> getTicketsByUserName(
+    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByUserName(
         @RequestBody String userName,
-        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
 
-    @Operation(summary = "티켓 상태로 티켓 조회", description = "티켓 상태로 티켓을 조회합니다.")
-    @GetMapping("/byStatus")
-    ResponseEntity<Page<TicketResponse>> getTicketsByStatus(
-        @RequestBody TicketStatus status,
-        @RequestParam(defaultValue = "0")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
 
     @Operation(summary = "전화번호로 티켓 조회", description = "전화번호로 티켓을 조회합니다.")
     @GetMapping("/byPhoneNumber")
-    ResponseEntity<Page<TicketResponse>> getTicketsByPhoneNumber(
+    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByPhoneNumber(
         @RequestBody String phoneNumber,
-        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
 
     @Operation(summary = "해당 날짜 공연 티켓 조회", description = "해당 날짜의 공연 관련 티켓을 조회합니다.")
     @GetMapping("/byShowDate")
-    ResponseEntity<Page<TicketResponse>> getTicketsByShowDate(
+    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByShowDate(
         @RequestBody LocalDateTime showDate,
-        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
      */

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -9,6 +9,7 @@ import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
+import com.uket.app.admin.api.enums.TicketSearchType;
 import com.uket.core.dto.response.ErrorResponse;
 import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.enums.TicketStatus;
@@ -100,61 +101,18 @@ public interface TicketApi {
         @RequestParam(defaultValue = "10")int size
     );
 
-    @Operation(summary = "티켓 상태로 티켓 페이지별 조회 API", description = "티켓 상태로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @GetMapping("/search/{ticketStatus}")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByStatus(
-        @PathVariable("ticketStatus") TicketStatus ticketStatus,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-
-    @Operation(summary = "사용자 이름으로 티켓 페이지별 조회 API", description = "사용자 이름으로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/userName")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByUserName(
-        @RequestBody UserNameRequest userNameRequest,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-
-    @Operation(summary = "전화번호로 티켓 페이지별 조회 API", description = "전화번호로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/phoneNumber")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByPhoneNumber(
-        @RequestBody PhoneNumberRequest phoneNumberRequest,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-    @Operation(summary = "해당 날짜 공연 티켓 페이지별로 조회 API", description = "해당 날짜의 공연 관련 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/showDate")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(
-        @RequestBody ShowDateRequest showDateRequest,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-    @Operation(summary = "사용자 구분으로 티켓 페이지별로 조회 API", description = "티켓을 일반인과 재학생으로 구분해 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/{reservationUserType}")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(
-        @PathVariable("reservationUserType")ReservationUserType reservationUserType,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-    @Operation(summary = "주문일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 주문 일시로 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/createdAt")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(
-        @RequestBody CreatedAtRequest createdAtRequest,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-    @Operation(summary = "업데이트일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 업데이트 일시로 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @PostMapping("/search/modifiedAt")
-    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByModifiedAt(
-        @RequestBody ModifiedAtRequest modifiedAtRequest,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
+    @Operation(summary = "티켓 검색 API", description = "다양한 기준으로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @GetMapping("/search")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTickets(
+        @RequestParam TicketSearchType searchType,
+        @RequestParam(required = false) TicketStatus status,
+        @RequestParam(required = false) String userName,
+        @RequestParam(required = false) String phoneNumber,
+        @RequestParam(required = false) LocalDateTime showDate,
+        @RequestParam(required = false) ReservationUserType reservationUserType,
+        @RequestParam(required = false) LocalDateTime createdAt,
+        @RequestParam(required = false) LocalDateTime modifiedAt,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "10") int size
     );
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,6 +1,7 @@
 package com.uket.app.admin.api.controller;
 
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
+import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
 import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -119,13 +121,12 @@ public interface TicketApi {
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
-    /*
+
     @Operation(summary = "해당 날짜 공연 티켓 페이지별로 조회 API", description = "해당 날짜의 공연 관련 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @GetMapping("/byShowDate")
+    @PostMapping("/search/showDate")
     ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(
-        @RequestBody LocalDateTime showDate,
+        @RequestBody ShowDateRequest showDateRequest,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
-     */
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,5 +1,6 @@
 package com.uket.app.admin.api.controller;
 
+import com.uket.app.admin.api.dto.request.CreatedAtRequest;
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
 import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -135,6 +137,14 @@ public interface TicketApi {
     @PostMapping("/search/{reservationUserType}")
     ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(
         @PathVariable("reservationUserType")ReservationUserType reservationUserType,
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
+
+    @Operation(summary = "주문일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 주문일시 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @PostMapping("/search/createdAt")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(
+        @RequestBody CreatedAtRequest createdAtRequest,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,6 +1,7 @@
 package com.uket.app.admin.api.controller;
 
 import com.uket.app.admin.api.dto.request.CreatedAtRequest;
+import com.uket.app.admin.api.dto.request.ModifiedAtRequest;
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
 import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
@@ -141,10 +142,18 @@ public interface TicketApi {
         @RequestParam(defaultValue = "10")int size
     );
 
-    @Operation(summary = "주문일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 주문일시 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @Operation(summary = "주문일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 주문 일시로 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
     @PostMapping("/search/createdAt")
     ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(
         @RequestBody CreatedAtRequest createdAtRequest,
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
+
+    @Operation(summary = "업데이트일시로 구분해 티켓 페이지별로 조회 API", description = "티켓을 업데이트 일시로 구분해 같은 시간에 생성된 티켓을 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @PostMapping("/search/modifiedAt")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByModifiedAt(
+        @RequestBody ModifiedAtRequest modifiedAtRequest,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -8,6 +8,7 @@ import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
 import com.uket.core.dto.response.ErrorResponse;
+import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.enums.TicketStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -126,6 +127,14 @@ public interface TicketApi {
     @PostMapping("/search/showDate")
     ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(
         @RequestBody ShowDateRequest showDateRequest,
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
+
+    @Operation(summary = "사용자 구분으로 티켓 페이지별로 조회 API", description = "티켓을 일반인과 재학생으로 구분해 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @PostMapping("/search/{reservationUserType}")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(
+        @PathVariable("reservationUserType")ReservationUserType reservationUserType,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,5 +1,6 @@
 package com.uket.app.admin.api.controller;
 
+import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
@@ -86,40 +87,44 @@ public interface TicketApi {
             @PathVariable("ticketStatus") TicketStatus ticketStatus
     );
 
-    @Operation(summary = "전체 티켓 조회", description = "전체 티켓을 조회합니다.")
+    @Operation(summary = "전체 티켓 페이지별 조회", description = "전체 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/all")
-    ResponseEntity<Page<TicketResponse>> getAllTickets(int page, int size);
+    ResponseEntity<CustomPageResponse<TicketResponse>> getAllTickets(
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
 
-
+    /*
     @Operation(summary = "사용자 이름으로 티켓 조회", description = "사용자 이름으로 티켓을 조회합니다.")
     @GetMapping("/byUserName")
     ResponseEntity<Page<TicketResponse>> getTicketsByUserName(
         @RequestBody String userName,
-        int page,
-        int size
+        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "10")int size
     );
 
     @Operation(summary = "티켓 상태로 티켓 조회", description = "티켓 상태로 티켓을 조회합니다.")
     @GetMapping("/byStatus")
     ResponseEntity<Page<TicketResponse>> getTicketsByStatus(
         @RequestBody TicketStatus status,
-        int page,
-        int size
+        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "10")int size
     );
 
     @Operation(summary = "전화번호로 티켓 조회", description = "전화번호로 티켓을 조회합니다.")
     @GetMapping("/byPhoneNumber")
     ResponseEntity<Page<TicketResponse>> getTicketsByPhoneNumber(
         @RequestBody String phoneNumber,
-        int page,
-        int size
+        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "10")int size
     );
 
     @Operation(summary = "해당 날짜 공연 티켓 조회", description = "해당 날짜의 공연 관련 티켓을 조회합니다.")
     @GetMapping("/byShowDate")
     ResponseEntity<Page<TicketResponse>> getTicketsByShowDate(
         @RequestBody LocalDateTime showDate,
-        int page,
-        int size
+        @RequestParam(defaultValue = "0")int page,
+        @RequestParam(defaultValue = "10")int size
     );
+     */
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,6 +1,7 @@
 package com.uket.app.admin.api.controller;
 
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
+import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
 import com.uket.core.dto.response.ErrorResponse;
 import com.uket.domain.ticket.enums.TicketStatus;
@@ -11,11 +12,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "어드민용 티켓 관리 API", description = "어드민용 티켓 관리 API")
@@ -78,5 +84,42 @@ public interface TicketApi {
     ResponseEntity<UpdateTicketStatusResponse> updateTicketStatus(
             @PathVariable("ticketId") Long ticketId,
             @PathVariable("ticketStatus") TicketStatus ticketStatus
+    );
+
+    @Operation(summary = "전체 티켓 조회", description = "전체 티켓을 조회합니다.")
+    @GetMapping("/all")
+    ResponseEntity<Page<TicketResponse>> getAllTickets(int page, int size);
+
+
+    @Operation(summary = "사용자 이름으로 티켓 조회", description = "사용자 이름으로 티켓을 조회합니다.")
+    @GetMapping("/byUserName")
+    ResponseEntity<Page<TicketResponse>> getTicketsByUserName(
+        @RequestBody String userName,
+        int page,
+        int size
+    );
+
+    @Operation(summary = "티켓 상태로 티켓 조회", description = "티켓 상태로 티켓을 조회합니다.")
+    @GetMapping("/byStatus")
+    ResponseEntity<Page<TicketResponse>> getTicketsByStatus(
+        @RequestBody TicketStatus status,
+        int page,
+        int size
+    );
+
+    @Operation(summary = "전화번호로 티켓 조회", description = "전화번호로 티켓을 조회합니다.")
+    @GetMapping("/byPhoneNumber")
+    ResponseEntity<Page<TicketResponse>> getTicketsByPhoneNumber(
+        @RequestBody String phoneNumber,
+        int page,
+        int size
+    );
+
+    @Operation(summary = "해당 날짜 공연 티켓 조회", description = "해당 날짜의 공연 관련 티켓을 조회합니다.")
+    @GetMapping("/byShowDate")
+    ResponseEntity<Page<TicketResponse>> getTicketsByShowDate(
+        @RequestBody LocalDateTime showDate,
+        int page,
+        int size
     );
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -1,5 +1,7 @@
 package com.uket.app.admin.api.controller;
 
+import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
+import com.uket.app.admin.api.dto.request.UserNameRequest;
 import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
@@ -18,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -85,42 +88,42 @@ public interface TicketApi {
             @PathVariable("ticketStatus") TicketStatus ticketStatus
     );
 
-    @Operation(summary = "전체 티켓 페이지별 조회", description = "전체 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @Operation(summary = "전체 티켓 페이지별 조회 API", description = "전체 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/search/all")
-    ResponseEntity<CustomPageResponse<TicketResponse>> getAllTickets(
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchAllTickets(
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
 
-    @Operation(summary = "티켓 상태로 티켓 페이지별 조회", description = "티켓 상태로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @Operation(summary = "티켓 상태로 티켓 페이지별 조회 API", description = "티켓 상태로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/search/{ticketStatus}")
-    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByStatus(
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByStatus(
         @PathVariable("ticketStatus") TicketStatus ticketStatus,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size
     );
 
+
+    @Operation(summary = "사용자 이름으로 티켓 페이지별 조회 API", description = "사용자 이름으로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @PostMapping("/search/userName")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByUserName(
+        @RequestBody UserNameRequest userNameRequest,
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
+
+
+    @Operation(summary = "전화번호로 티켓 페이지별 조회 API", description = "전화번호로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @GetMapping("/search/phoneNumber")
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByPhoneNumber(
+        @RequestBody PhoneNumberRequest phoneNumberRequest,
+        @RequestParam(defaultValue = "1")int page,
+        @RequestParam(defaultValue = "10")int size
+    );
     /*
-    @Operation(summary = "사용자 이름으로 티켓 조회", description = "사용자 이름으로 티켓을 조회합니다.")
-    @GetMapping("/byUserName")
-    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByUserName(
-        @RequestBody String userName,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-
-    @Operation(summary = "전화번호로 티켓 조회", description = "전화번호로 티켓을 조회합니다.")
-    @GetMapping("/byPhoneNumber")
-    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByPhoneNumber(
-        @RequestBody String phoneNumber,
-        @RequestParam(defaultValue = "1")int page,
-        @RequestParam(defaultValue = "10")int size
-    );
-
-    @Operation(summary = "해당 날짜 공연 티켓 조회", description = "해당 날짜의 공연 관련 티켓을 조회합니다.")
+    @Operation(summary = "해당 날짜 공연 티켓 페이지별로 조회 API", description = "해당 날짜의 공연 관련 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/byShowDate")
-    ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByShowDate(
+    ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(
         @RequestBody LocalDateTime showDate,
         @RequestParam(defaultValue = "1")int page,
         @RequestParam(defaultValue = "10")int size

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/TicketApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -114,7 +113,7 @@ public interface TicketApi {
 
 
     @Operation(summary = "전화번호로 티켓 페이지별 조회 API", description = "전화번호로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
-    @GetMapping("/search/phoneNumber")
+    @PostMapping("/search/phoneNumber")
     ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByPhoneNumber(
         @RequestBody PhoneNumberRequest phoneNumberRequest,
         @RequestParam(defaultValue = "1")int page,

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -77,6 +77,7 @@ public class TicketController implements TicketApi {
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);
     }
+
     /*
     @Override
     public ResponseEntity<Page<TicketResponse>> searchTicketsByShowDate(LocalDateTime showDate, int page, int size) {

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -10,6 +10,7 @@ import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
+import com.uket.app.admin.api.enums.TicketSearchType;
 import com.uket.app.admin.api.service.EnterShowService;
 import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.dto.CheckTicketDto;
@@ -59,63 +60,50 @@ public class TicketController implements TicketApi {
     }
 
     @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByStatus(TicketStatus status, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByStatus(status,page-1, size);
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTickets(
+        TicketSearchType searchType,
+        TicketStatus status,
+        String userName,
+        String phoneNumber,
+        LocalDateTime showDate,
+        ReservationUserType reservationUserType,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        int page,
+        int size
+    ) {
+        Page<CheckTicketDto> tickets;
+
+        switch (searchType) {
+            case STATUS:
+                tickets = ticketService.searchTicketsByStatus(status, page - 1, size);
+                break;
+            case USER_NAME:
+                tickets = ticketService.searchTicketsByUserName(userName, page - 1, size);
+                break;
+            case PHONE_NUMBER:
+                tickets = ticketService.searchTicketsByPhoneNumber(phoneNumber, page - 1, size);
+                break;
+            case SHOW_DATE:
+                tickets = ticketService.searchTicketsByShowStartDate(showDate, page - 1, size);
+                break;
+            case RESERVATION_USER_TYPE:
+                tickets = ticketService.searchTicketsByReservationUserType(reservationUserType, page - 1, size);
+                break;
+            case CREATED_AT:
+                Timestamp createdAtLocal = Timestamp.valueOf(createdAt);
+                tickets = ticketService.searchTicketsByCreatedAt(createdAtLocal, page - 1, size);
+                break;
+            case MODIFIED_AT:
+                Timestamp modifiedAtLocal = Timestamp.valueOf(modifiedAt);
+                tickets = ticketService.searchTicketsByModifiedAt(modifiedAtLocal, page - 1, size);
+                break;
+            default:
+                throw new IllegalArgumentException("잘못된 검색 타입입니다.");
+        }
+
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);
     }
-
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByUserName(UserNameRequest userNameRequest, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByUserName(userNameRequest.userName(), page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByPhoneNumber(PhoneNumberRequest phoneNumberRequest, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByPhoneNumber(phoneNumberRequest.phoneNumber(), page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(ShowDateRequest showDateRequest, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByShowStartDate(showDateRequest.showDate(), page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(ReservationUserType reservationUserType, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByReservationUserType(reservationUserType, page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(CreatedAtRequest createdAtRequest, int page, int size) {
-        Timestamp createdAt = createdAtRequest.toTimestamp();
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByCreatedAt(createdAt, page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
-    @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByModifiedAt(ModifiedAtRequest modifiedAtRequest, int page, int size) {
-        Timestamp modifiedAt = modifiedAtRequest.toTimestamp();
-        Page<CheckTicketDto> tickets = ticketService.searchTicketsByModifiedAt(modifiedAt, page-1, size);
-        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
-        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
-        return ResponseEntity.ok(customResponse);
-    }
-
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -2,6 +2,7 @@ package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
+import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
 import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
@@ -78,11 +79,13 @@ public class TicketController implements TicketApi {
         return ResponseEntity.ok(customResponse);
     }
 
-    /*
+
     @Override
-    public ResponseEntity<Page<TicketResponse>> searchTicketsByShowDate(LocalDateTime showDate, int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.searchTicketsByShowStartDate(showDate, page-1, size);
-        return ResponseEntity.ok(ticketResponses);
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(ShowDateRequest showDateRequest, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByShowStartDate(showDateRequest.showDate(), page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
     }
-    */
+
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -2,6 +2,7 @@ package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
 import com.uket.app.admin.api.dto.request.CreatedAtRequest;
+import com.uket.app.admin.api.dto.request.ModifiedAtRequest;
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
 import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
@@ -103,6 +104,15 @@ public class TicketController implements TicketApi {
     public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(CreatedAtRequest createdAtRequest, int page, int size) {
         Timestamp createdAt = createdAtRequest.toTimestamp();
         Page<CheckTicketDto> tickets = ticketService.searchTicketsByCreatedAt(createdAt, page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
+
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByModifiedAt(ModifiedAtRequest modifiedAtRequest, int page, int size) {
+        Timestamp modifiedAt = modifiedAtRequest.toTimestamp();
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByModifiedAt(modifiedAt, page-1, size);
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -1,10 +1,12 @@
 package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
+import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
 import com.uket.app.admin.api.service.EnterShowService;
+import com.uket.domain.ticket.dto.CheckTicketDto;
 import com.uket.domain.ticket.dto.TicketDto;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
@@ -42,11 +44,14 @@ public class TicketController implements TicketApi {
     }
 
     @Override
-    public ResponseEntity<Page<TicketResponse>> getAllTickets(int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.getAllTickets(page, size);
-        return ResponseEntity.ok(ticketResponses);
+    public ResponseEntity<CustomPageResponse<TicketResponse>> getAllTickets(int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.getAllTickets(page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
     }
 
+    /*
     @Override
     public ResponseEntity<Page<TicketResponse>> getTicketsByUserName(String userName, int page, int size) {
         Page<TicketResponse> ticketResponses = ticketService.getTicketsByUserName(userName, page, size);
@@ -70,5 +75,5 @@ public class TicketController implements TicketApi {
         Page<TicketResponse> ticketResponses = ticketService.getTicketsByShowStartDate(showDate, page, size);
         return ResponseEntity.ok(ticketResponses);
     }
-
+    */
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -9,6 +9,7 @@ import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
 import com.uket.app.admin.api.service.EnterShowService;
+import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.dto.CheckTicketDto;
 import com.uket.domain.ticket.dto.TicketDto;
 import com.uket.domain.ticket.entity.Ticket;
@@ -83,6 +84,14 @@ public class TicketController implements TicketApi {
     @Override
     public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByShowDate(ShowDateRequest showDateRequest, int page, int size) {
         Page<CheckTicketDto> tickets = ticketService.searchTicketsByShowStartDate(showDateRequest.showDate(), page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
+
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(ReservationUserType reservationUserType, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByReservationUserType(reservationUserType, page-1, size);
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -1,6 +1,7 @@
 package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
+import com.uket.app.admin.api.dto.request.CreatedAtRequest;
 import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
 import com.uket.app.admin.api.dto.request.ShowDateRequest;
 import com.uket.app.admin.api.dto.request.UserNameRequest;
@@ -15,6 +16,7 @@ import com.uket.domain.ticket.dto.TicketDto;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.ticket.service.TicketService;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -92,6 +94,15 @@ public class TicketController implements TicketApi {
     @Override
     public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByReservationUserType(ReservationUserType reservationUserType, int page, int size) {
         Page<CheckTicketDto> tickets = ticketService.searchTicketsByReservationUserType(reservationUserType, page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
+
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByCreatedAt(CreatedAtRequest createdAtRequest, int page, int size) {
+        Timestamp createdAt = createdAtRequest.toTimestamp();
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByCreatedAt(createdAt, page-1, size);
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -1,6 +1,8 @@
 package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
+import com.uket.app.admin.api.dto.request.PhoneNumberRequest;
+import com.uket.app.admin.api.dto.request.UserNameRequest;
 import com.uket.app.admin.api.dto.response.CustomPageResponse;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
 import com.uket.app.admin.api.dto.response.TicketResponse;
@@ -44,37 +46,41 @@ public class TicketController implements TicketApi {
     }
 
     @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> getAllTickets(int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.getAllTickets(page-1, size);
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchAllTickets(int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchAllTickets(page-1, size);
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);
     }
 
     @Override
-    public ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByStatus(TicketStatus status, int page, int size) {
-        Page<CheckTicketDto> tickets = ticketService.getTicketsByStatus(status,page-1, size);
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByStatus(TicketStatus status, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByStatus(status,page-1, size);
         Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
         CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
         return ResponseEntity.ok(customResponse);
     }
 
+
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByUserName(UserNameRequest userNameRequest, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByUserName(userNameRequest.userName(), page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
+
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> searchTicketsByPhoneNumber(PhoneNumberRequest phoneNumberRequest, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.searchTicketsByPhoneNumber(phoneNumberRequest.phoneNumber(), page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
     /*
     @Override
-    public ResponseEntity<Page<TicketResponse>> getTicketsByUserName(String userName, int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.getTicketsByUserName(userName, page, size);
-        return ResponseEntity.ok(ticketResponses);
-    }
-
-    @Override
-    public ResponseEntity<Page<TicketResponse>> getTicketsByPhoneNumber(String phoneNumber, int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.getTicketsByPhoneNumber(phoneNumber, page, size);
-        return ResponseEntity.ok(ticketResponses);
-    }
-
-    @Override
-    public ResponseEntity<Page<TicketResponse>> getTicketsByShowDate(LocalDateTime showDate, int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.getTicketsByShowStartDate(showDate, page, size);
+    public ResponseEntity<Page<TicketResponse>> searchTicketsByShowDate(LocalDateTime showDate, int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.searchTicketsByShowStartDate(showDate, page-1, size);
         return ResponseEntity.ok(ticketResponses);
     }
     */

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -2,13 +2,17 @@ package com.uket.app.admin.api.controller.impl;
 
 import com.uket.app.admin.api.controller.TicketApi;
 import com.uket.app.admin.api.dto.response.EnterShowResponse;
+import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.app.admin.api.dto.response.UpdateTicketStatusResponse;
 import com.uket.app.admin.api.service.EnterShowService;
 import com.uket.domain.ticket.dto.TicketDto;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.ticket.service.TicketService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -36,4 +40,35 @@ public class TicketController implements TicketApi {
         UpdateTicketStatusResponse response = UpdateTicketStatusResponse.from(ticket);
         return ResponseEntity.ok(response);
     }
+
+    @Override
+    public ResponseEntity<Page<TicketResponse>> getAllTickets(int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.getAllTickets(page, size);
+        return ResponseEntity.ok(ticketResponses);
+    }
+
+    @Override
+    public ResponseEntity<Page<TicketResponse>> getTicketsByUserName(String userName, int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.getTicketsByUserName(userName, page, size);
+        return ResponseEntity.ok(ticketResponses);
+    }
+
+    @Override
+    public ResponseEntity<Page<TicketResponse>> getTicketsByStatus(TicketStatus status, int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.getTicketsByStatus(status, page, size);
+        return ResponseEntity.ok(ticketResponses);
+    }
+
+    @Override
+    public ResponseEntity<Page<TicketResponse>> getTicketsByPhoneNumber(String phoneNumber, int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.getTicketsByPhoneNumber(phoneNumber, page, size);
+        return ResponseEntity.ok(ticketResponses);
+    }
+
+    @Override
+    public ResponseEntity<Page<TicketResponse>> getTicketsByShowDate(LocalDateTime showDate, int page, int size) {
+        Page<TicketResponse> ticketResponses = ticketService.getTicketsByShowStartDate(showDate, page, size);
+        return ResponseEntity.ok(ticketResponses);
+    }
+
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -51,16 +51,18 @@ public class TicketController implements TicketApi {
         return ResponseEntity.ok(customResponse);
     }
 
+    @Override
+    public ResponseEntity<CustomPageResponse<TicketResponse>> getTicketsByStatus(TicketStatus status, int page, int size) {
+        Page<CheckTicketDto> tickets = ticketService.getTicketsByStatus(status,page-1, size);
+        Page<TicketResponse> ticketResponses = tickets.map(TicketResponse::from);
+        CustomPageResponse<TicketResponse> customResponse = new CustomPageResponse<>(ticketResponses);
+        return ResponseEntity.ok(customResponse);
+    }
+
     /*
     @Override
     public ResponseEntity<Page<TicketResponse>> getTicketsByUserName(String userName, int page, int size) {
         Page<TicketResponse> ticketResponses = ticketService.getTicketsByUserName(userName, page, size);
-        return ResponseEntity.ok(ticketResponses);
-    }
-
-    @Override
-    public ResponseEntity<Page<TicketResponse>> getTicketsByStatus(TicketStatus status, int page, int size) {
-        Page<TicketResponse> ticketResponses = ticketService.getTicketsByStatus(status, page, size);
         return ResponseEntity.ok(ticketResponses);
     }
 

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/CreatedAtRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/CreatedAtRequest.java
@@ -1,0 +1,18 @@
+package com.uket.app.admin.api.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+public record CreatedAtRequest(
+    @NotNull
+    @Schema(description = "티켓 생성 일자", example = "2024-10-10T14:30:00")
+    LocalDateTime createdAt
+) {
+    public Timestamp toTimestamp() {
+        return Timestamp.valueOf(createdAt.withNano(0));
+    }
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/CreatedAtRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/CreatedAtRequest.java
@@ -13,6 +13,6 @@ public record CreatedAtRequest(
     LocalDateTime createdAt
 ) {
     public Timestamp toTimestamp() {
-        return Timestamp.valueOf(createdAt.withNano(0));
+        return Timestamp.valueOf(createdAt);
     }
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ModifiedAtRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ModifiedAtRequest.java
@@ -11,6 +11,6 @@ public record ModifiedAtRequest(
     LocalDateTime modifiedAt
 ) {
     public Timestamp toTimestamp() {
-        return Timestamp.valueOf(modifiedAt.withNano(0));
+        return Timestamp.valueOf(modifiedAt);
     }
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ModifiedAtRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ModifiedAtRequest.java
@@ -1,0 +1,16 @@
+package com.uket.app.admin.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+public record ModifiedAtRequest(
+    @NotNull
+    @Schema(description = "티켓 수정 일자", example = "2024-10-10T14:30:00")
+    LocalDateTime modifiedAt
+) {
+    public Timestamp toTimestamp() {
+        return Timestamp.valueOf(modifiedAt.withNano(0));
+    }
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/PhoneNumberRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/PhoneNumberRequest.java
@@ -1,0 +1,14 @@
+package com.uket.app.admin.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PhoneNumberRequest(
+    @NotBlank
+    @Pattern(regexp = "\\d{10,11}", message = "전화번호는 10자리 또는 11자리 숫자여야 합니다.")
+    @Schema(description = "사용자의 전화번호", example = "01012345678")
+    String phoneNumber
+) {
+
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ShowDateRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/ShowDateRequest.java
@@ -1,0 +1,14 @@
+package com.uket.app.admin.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record ShowDateRequest(
+    @NotNull
+    @Schema(description = "공연 날짜", example = "2024-09-05T00:00:00")
+    LocalDateTime showDate
+) {
+
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/UserNameRequest.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/request/UserNameRequest.java
@@ -1,0 +1,12 @@
+package com.uket.app.admin.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserNameRequest(
+    @NotBlank
+    @Schema(description = "검색하려는 사용자 이름", example = "곽민재")
+    String userName
+) {
+
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/CustomPageResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/CustomPageResponse.java
@@ -1,0 +1,31 @@
+package com.uket.app.admin.api.dto.response;
+
+import org.springframework.data.domain.Page;
+import java.util.List;
+
+public record CustomPageResponse<T>(
+    List<T> content         ,
+    int pageNumber,
+    int pageSize,
+    boolean first,
+    boolean last,
+    long totalElements,
+    int totalPages,
+    int numberOfElements,
+    boolean empty
+) {
+    public CustomPageResponse(Page<T> page) {
+        this(
+            page.getContent(),
+            page.getNumber() + 1,
+            page.getSize(),
+            page.isFirst(),
+            page.isLast(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.getNumberOfElements(),
+            page.isEmpty()
+        );
+    }
+}
+

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
@@ -12,8 +12,8 @@ public record TicketResponse(
     String depositorName,
     LocalDateTime showDate,
     LocalDateTime showTime,
-    Timestamp orderDate,
-    Timestamp updatedDate,
+    LocalDateTime orderDate,
+    LocalDateTime updatedDate,
     String ticketStatus,
     String userType
 ) {

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
@@ -22,7 +22,7 @@ public record TicketResponse(
         return TicketResponse.builder()
             .ticketId(checkTicketDto.ticketId())
             .depositorName(checkTicketDto.userName())
-            .showDate(checkTicketDto.showDate())
+            .showDate(checkTicketDto.showStartDate())
             .showTime(checkTicketDto.enterStartTime())
             .orderDate(checkTicketDto.createdAt())
             .updatedDate(checkTicketDto.updatedAt())

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
@@ -1,0 +1,34 @@
+package com.uket.app.admin.api.dto.response;
+
+import com.uket.domain.ticket.entity.Ticket;
+import com.uket.domain.ticket.enums.TicketStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.sql.Timestamp;
+
+@Builder
+public record TicketResponse(
+    Long ticketId,
+    String depositorName,
+    LocalDateTime showDate,
+    LocalDateTime showTime,
+    Timestamp orderDate,
+    Timestamp updatedDate,
+    TicketStatus status,
+    String userType
+) {
+
+    public static TicketResponse from(Ticket ticket) {
+        return TicketResponse.builder()
+            .ticketId(ticket.getId())
+            .depositorName(ticket.getUser().getName())
+            .showDate(ticket.getShow().getStartDate())
+            .showTime(ticket.getReservation().getStartTime())
+            .orderDate(ticket.getCreatedAt())
+            .updatedDate(ticket.getModifiedAt())
+            .status(ticket.getStatus())
+            .userType(ticket.getReservation().getType().getValue())
+            .build();
+    }
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/TicketResponse.java
@@ -1,7 +1,6 @@
 package com.uket.app.admin.api.dto.response;
 
-import com.uket.domain.ticket.entity.Ticket;
-import com.uket.domain.ticket.enums.TicketStatus;
+import com.uket.domain.ticket.dto.CheckTicketDto;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -15,20 +14,20 @@ public record TicketResponse(
     LocalDateTime showTime,
     Timestamp orderDate,
     Timestamp updatedDate,
-    TicketStatus status,
+    String ticketStatus,
     String userType
 ) {
 
-    public static TicketResponse from(Ticket ticket) {
+    public static TicketResponse from(CheckTicketDto checkTicketDto) {
         return TicketResponse.builder()
-            .ticketId(ticket.getId())
-            .depositorName(ticket.getUser().getName())
-            .showDate(ticket.getShow().getStartDate())
-            .showTime(ticket.getReservation().getStartTime())
-            .orderDate(ticket.getCreatedAt())
-            .updatedDate(ticket.getModifiedAt())
-            .status(ticket.getStatus())
-            .userType(ticket.getReservation().getType().getValue())
+            .ticketId(checkTicketDto.ticketId())
+            .depositorName(checkTicketDto.userName())
+            .showDate(checkTicketDto.showDate())
+            .showTime(checkTicketDto.enterStartTime())
+            .orderDate(checkTicketDto.createdAt())
+            .updatedDate(checkTicketDto.updatedAt())
+            .ticketStatus(checkTicketDto.ticketStatus())
+            .userType(checkTicketDto.userType())
             .build();
     }
 }

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/enums/TicketSearchType.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/enums/TicketSearchType.java
@@ -1,0 +1,11 @@
+package com.uket.app.admin.api.enums;
+
+public enum TicketSearchType {
+    STATUS,
+    USER_NAME,
+    PHONE_NUMBER,
+    SHOW_DATE,
+    RESERVATION_USER_TYPE,
+    CREATED_AT,
+    MODIFIED_AT
+}

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
@@ -27,7 +27,9 @@ public record CheckTicketDto(
 
     Long ticketId,
 
-    Timestamp createdAt
+    Timestamp createdAt,
+
+    Timestamp updatedAt
 ) {
     public static CheckTicketDto from(Ticket ticket) {
         Users user = ticket.getUser();
@@ -49,6 +51,7 @@ public record CheckTicketDto(
             .eventName(event.getName())
             .ticketId(ticket.getId())
             .createdAt(ticket.getCreatedAt())
+            .updatedAt(ticket.getModifiedAt())
             .build();
     }
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 @Builder
 public record CheckTicketDto(
     String userName,
-    LocalDateTime showDate,
+    LocalDateTime showStartDate,
     LocalDateTime enterStartTime,
     LocalDateTime enterEndTime,
     String showLocation,
@@ -39,7 +39,7 @@ public record CheckTicketDto(
 
         return CheckTicketDto.builder()
             .userName(user.getName())
-            .showDate(show.getStartDate())
+            .showStartDate(show.getStartDate())
             .enterStartTime(reservation.getStartTime())
             .enterEndTime(reservation.getEndTime())
             .showLocation(show.getLocation())

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
@@ -27,9 +27,9 @@ public record CheckTicketDto(
 
     Long ticketId,
 
-    Timestamp createdAt,
+    LocalDateTime createdAt,
 
-    Timestamp updatedAt
+    LocalDateTime updatedAt
 ) {
     public static CheckTicketDto from(Ticket ticket) {
         Users user = ticket.getUser();
@@ -50,8 +50,8 @@ public record CheckTicketDto(
             .showName(show.getName())
             .eventName(event.getName())
             .ticketId(ticket.getId())
-            .createdAt(ticket.getCreatedAt())
-            .updatedAt(ticket.getModifiedAt())
+            .createdAt(ticket.getCreatedAt().toLocalDateTime())
+            .updatedAt(ticket.getModifiedAt().toLocalDateTime())
             .build();
     }
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -2,6 +2,7 @@ package com.uket.domain.ticket.repository;
 
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.entity.Shows;
+import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.user.entity.Users;
@@ -38,6 +39,6 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
     Page<Ticket> findByShowStartDate(LocalDateTime startDate, Pageable pageable);
 
-
+    Page<Ticket> findByReservationType(ReservationUserType userType, Pageable pageable);
 }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -3,6 +3,7 @@ package com.uket.domain.ticket.repository;
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.entity.Shows;
 import com.uket.domain.event.enums.ReservationUserType;
+import com.uket.domain.ticket.dto.CheckTicketDto;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.user.entity.Users;
@@ -44,10 +45,7 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
     Page<Ticket> findByReservationType(ReservationUserType userType, Pageable pageable);
 
-    Page<Ticket> findByCreatedAt(Timestamp createdAt, Pageable pageable);
-
     Page<Ticket> findByCreatedAtBetween(Timestamp createdAt,Timestamp endTimestamp, Pageable pageable);
-    Page<Ticket> findByModifiedAt(Timestamp modifiedAt, Pageable pageable);
 
     Page<Ticket> findByModifiedAtBetween(Timestamp modifiedAt,Timestamp endTimestamp, Pageable pageable);
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -46,7 +46,9 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
     Page<Ticket> findByCreatedAt(Timestamp createdAt, Pageable pageable);
 
+    Page<Ticket> findByCreatedAtBetween(Timestamp createdAt,Timestamp endTimestamp, Pageable pageable);
     Page<Ticket> findByModifiedAt(Timestamp modifiedAt, Pageable pageable);
 
+    Page<Ticket> findByModifiedAtBetween(Timestamp modifiedAt,Timestamp endTimestamp, Pageable pageable);
 }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -6,12 +6,15 @@ import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.user.entity.Users;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
@@ -40,5 +43,10 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
     Page<Ticket> findByShowStartDate(LocalDateTime startDate, Pageable pageable);
 
     Page<Ticket> findByReservationType(ReservationUserType userType, Pageable pageable);
+
+    Page<Ticket> findByCreatedAt(Timestamp createdAt, Pageable pageable);
+
+    Page<Ticket> findByModifiedAt(Timestamp modifiedAt, Pageable pageable);
+
 }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -5,9 +5,12 @@ import com.uket.domain.event.entity.Shows;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
 import com.uket.domain.user.entity.Users;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
@@ -26,5 +29,15 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findAllByUserId(Long userId);
 
     List<Ticket> findAllByUserIdAndStatusNot(Long userId, TicketStatus status);
+
+    Page<Ticket> findByStatus(TicketStatus status, Pageable pageable);
+
+    Page<Ticket> findByUserName(String userName, Pageable pageable);
+
+    Page<Ticket> findByUserUserDetailsPhoneNumber(String phoneNumber, Pageable pageable);
+
+    Page<Ticket> findByShowStartDate(LocalDateTime startDate, Pageable pageable);
+
+
 }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -109,25 +109,28 @@ public class TicketService {
         return tickets.map(CheckTicketDto::from);
     }
 
-    /*
-    public Page<TicketResponse> getTicketsByStatus(TicketStatus status, int page, int size) {
+    @Transactional(readOnly = true)
+    public Page<CheckTicketDto> getTicketsByStatus(TicketStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByStatus(status, pageable);
-        return tickets.map(TicketResponse::from);
+        return tickets.map(CheckTicketDto::from);
     }
-
+    /*
+    @Transactional(readOnly = true)
     public Page<TicketResponse> getTicketsByUserName(String userName, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByUserName(userName, pageable);
         return tickets.map(TicketResponse::from);
     }
 
+    @Transactional(readOnly = true)
     public Page<TicketResponse> getTicketsByPhoneNumber(String phoneNumber, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByUserUserDetailsPhoneNumber(phoneNumber, pageable);
         return tickets.map(TicketResponse::from);
     }
 
+    @Transactional(readOnly = true)
     public Page<TicketResponse> getTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -1,5 +1,6 @@
 package com.uket.domain.ticket.service;
 
+import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.service.ReservationService;
@@ -11,9 +12,13 @@ import com.uket.domain.ticket.exception.TicketException;
 import com.uket.domain.ticket.repository.TicketRepository;
 import com.uket.domain.user.entity.Users;
 import com.uket.modules.redis.lock.aop.DistributedLock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,11 +93,44 @@ public class TicketService {
     }
 
 
+    @Transactional
     public Ticket updateTicketStatus(Long ticketId, TicketStatus ticketStatus) {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new TicketException(ErrorCode.FAIL_TO_FIND_TICKET));
 
         Ticket updatedTicket = ticket.updateStatus(ticketStatus);
         return ticketRepository.save(updatedTicket);
+    }
+
+
+    public Page<TicketResponse> getAllTickets(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findAll(pageable);
+        return tickets.map(TicketResponse::from);
+    }
+
+
+    public Page<TicketResponse> getTicketsByStatus(TicketStatus status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByStatus(status, pageable);
+        return tickets.map(TicketResponse::from);
+    }
+
+    public Page<TicketResponse> getTicketsByUserName(String userName, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByUserName(userName, pageable);
+        return tickets.map(TicketResponse::from);
+    }
+
+    public Page<TicketResponse> getTicketsByPhoneNumber(String phoneNumber, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByUserUserDetailsPhoneNumber(phoneNumber, pageable);
+        return tickets.map(TicketResponse::from);
+    }
+
+    public Page<TicketResponse> getTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);
+        return tickets.map(TicketResponse::from);
     }
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -13,6 +13,7 @@ import com.uket.domain.ticket.exception.TicketException;
 import com.uket.domain.ticket.repository.TicketRepository;
 import com.uket.domain.user.entity.Users;
 import com.uket.modules.redis.lock.aop.DistributedLock;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -143,6 +144,13 @@ public class TicketService {
     public Page<CheckTicketDto> searchTicketsByReservationUserType(ReservationUserType userType, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByReservationType(userType, pageable);
+        return tickets.map(CheckTicketDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CheckTicketDto> searchTicketsByCreatedAt(Timestamp createdAt, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByCreatedAt(createdAt, pageable);
         return tickets.map(CheckTicketDto::from);
     }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -2,6 +2,7 @@ package com.uket.domain.ticket.service;
 
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.entity.Reservation;
+import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.event.service.ReservationService;
 import com.uket.domain.ticket.dto.CancelTicketDto;
 import com.uket.domain.ticket.dto.CheckTicketDto;
@@ -135,6 +136,13 @@ public class TicketService {
     public Page<CheckTicketDto> searchTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);
+        return tickets.map(CheckTicketDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CheckTicketDto> searchTicketsByReservationUserType(ReservationUserType userType, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Ticket> tickets = ticketRepository.findByReservationType(userType, pageable);
         return tickets.map(CheckTicketDto::from);
     }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -103,38 +103,38 @@ public class TicketService {
 
 
     @Transactional(readOnly = true)
-    public Page<CheckTicketDto> getAllTickets(int page, int size) {
+    public Page<CheckTicketDto> searchAllTickets(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets =  ticketRepository.findAll(pageable);
         return tickets.map(CheckTicketDto::from);
     }
 
     @Transactional(readOnly = true)
-    public Page<CheckTicketDto> getTicketsByStatus(TicketStatus status, int page, int size) {
+    public Page<CheckTicketDto> searchTicketsByStatus(TicketStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByStatus(status, pageable);
         return tickets.map(CheckTicketDto::from);
     }
-    /*
+
     @Transactional(readOnly = true)
-    public Page<TicketResponse> getTicketsByUserName(String userName, int page, int size) {
+    public Page<CheckTicketDto> searchTicketsByUserName(String userName, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByUserName(userName, pageable);
-        return tickets.map(TicketResponse::from);
+        return tickets.map(CheckTicketDto::from);
     }
 
     @Transactional(readOnly = true)
-    public Page<TicketResponse> getTicketsByPhoneNumber(String phoneNumber, int page, int size) {
+    public Page<CheckTicketDto> searchTicketsByPhoneNumber(String phoneNumber, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByUserUserDetailsPhoneNumber(phoneNumber, pageable);
-        return tickets.map(TicketResponse::from);
+        return tickets.map(CheckTicketDto::from);
     }
-
+    /*
     @Transactional(readOnly = true)
-    public Page<TicketResponse> getTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
+    public Page<CheckTicketDto> searchTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);
-        return tickets.map(TicketResponse::from);
+        return tickets.map(CheckTicketDto::from);
     }
      */
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -1,10 +1,10 @@
 package com.uket.domain.ticket.service;
 
-import com.uket.app.admin.api.dto.response.TicketResponse;
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.service.ReservationService;
 import com.uket.domain.ticket.dto.CancelTicketDto;
+import com.uket.domain.ticket.dto.CheckTicketDto;
 import com.uket.domain.ticket.dto.CreateTicketDto;
 import com.uket.domain.ticket.entity.Ticket;
 import com.uket.domain.ticket.enums.TicketStatus;
@@ -12,7 +12,6 @@ import com.uket.domain.ticket.exception.TicketException;
 import com.uket.domain.ticket.repository.TicketRepository;
 import com.uket.domain.user.entity.Users;
 import com.uket.modules.redis.lock.aop.DistributedLock;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -103,13 +102,14 @@ public class TicketService {
     }
 
 
-    public Page<TicketResponse> getAllTickets(int page, int size) {
+    @Transactional(readOnly = true)
+    public Page<CheckTicketDto> getAllTickets(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Ticket> tickets = ticketRepository.findAll(pageable);
-        return tickets.map(TicketResponse::from);
+        Page<Ticket> tickets =  ticketRepository.findAll(pageable);
+        return tickets.map(CheckTicketDto::from);
     }
 
-
+    /*
     public Page<TicketResponse> getTicketsByStatus(TicketStatus status, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByStatus(status, pageable);
@@ -133,4 +133,5 @@ public class TicketService {
         Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);
         return tickets.map(TicketResponse::from);
     }
+     */
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -12,6 +12,7 @@ import com.uket.domain.ticket.exception.TicketException;
 import com.uket.domain.ticket.repository.TicketRepository;
 import com.uket.domain.user.entity.Users;
 import com.uket.modules.redis.lock.aop.DistributedLock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -129,12 +130,12 @@ public class TicketService {
         Page<Ticket> tickets = ticketRepository.findByUserUserDetailsPhoneNumber(phoneNumber, pageable);
         return tickets.map(CheckTicketDto::from);
     }
-    /*
+
     @Transactional(readOnly = true)
     public Page<CheckTicketDto> searchTicketsByShowStartDate(LocalDateTime startDate, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Ticket> tickets = ticketRepository.findByShowStartDate(startDate, pageable);
         return tickets.map(CheckTicketDto::from);
     }
-     */
+
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TicketService {
 
     private final TicketRepository ticketRepository;
@@ -150,7 +152,18 @@ public class TicketService {
     @Transactional(readOnly = true)
     public Page<CheckTicketDto> searchTicketsByCreatedAt(Timestamp createdAt, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Ticket> tickets = ticketRepository.findByCreatedAt(createdAt, pageable);
+        Timestamp endTimestamp = new Timestamp((createdAt.getTime() / 1000 + 1) * 1000);
+        Page<Ticket> tickets = ticketRepository.findByCreatedAtBetween(createdAt, endTimestamp,pageable);
+
+        return tickets.map(CheckTicketDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CheckTicketDto> searchTicketsByModifiedAt(Timestamp modifiedAt, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Timestamp endTimestamp = new Timestamp((modifiedAt.getTime() / 1000 + 1) * 1000);
+        Page<Ticket> tickets = ticketRepository.findByModifiedAtBetween(modifiedAt, endTimestamp,pageable);
+
         return tickets.map(CheckTicketDto::from);
     }
 


### PR DESCRIPTION
# 📌 개요
- 사용자 예매 내역을 페이지별로 검색 필터를 적용해 검색할 수 있도록 구현했습니다.

# 💻 작업사항
- [x] 전체 티켓 페이지별 조회 기능 구현
- [x] 티켓 상태로 페이지별 조회 기능 구현
- [x] 사용자 구분으로 페이지별 조회 기능 구현
- [x] 주문일시로 페이지별 조회 기능 구현
- [x] 업데이트일시로 페이지별 조회 기능 구현
- [x] 전화번호로 페이지별 조회 기능 구현
- [x] 공연 날짜로 페이지별 조회 기능 구현
- [x] 사용자 이름으로 페이지별 조회 기능 구현

# ❌ 주의사항
- 현재 예외 처리는 되어있지 않은 상태입니다.
- Page관련 변수들은 선택정 정보라고 생각해 @RequestParam으로 구현해두었습니다.

# 💡 코드 리뷰 요청사항
-  depositorName이 null인 경우가 있어 userName으로 검색 가능하도록 해놨는데 예금주명으로 변경해야할지 의견 부탁드립니다.
