### PR TITLE
[SVR-56] 입금 링크 제공 API 수정 - 명세 및 예외처리 추가 및 계좌 정보 제공

### DIFF
--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/service/EnterShowService.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/service/EnterShowService.java
@@ -23,6 +23,7 @@ public class EnterShowService {
     private final JwtTicketUtil jwtTicketUtil;
     private final TicketService ticketService;
 
+    @Transactional(readOnly = true)
     public TicketDto enterShow(String ticketToken) {
         tokenValidator.validateExpiredQRToken(ticketToken);
         tokenValidator.validateQRTokenCategory(JWT_PAYLOAD_VALUE_TICKET, ticketToken);

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -76,18 +76,9 @@ public interface EventApi {
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {
-                    @ExampleObject(name = "TI0009", description = "티켓의 아이디가 잘못된 경우 발생합니다.",
+                    @ExampleObject(name = "EV0001", description = "축제의 아이디가 잘못된 경우 발생합니다.",
                             value = """
-                                    {"code": "TI0009", "message": "해당 티켓을 찾을 수 없습니다. 티켓 아이디를 다시 확인해주세요."}
-                                    """
-                    )
-            }, schema = @Schema(implementation = ErrorResponse.class)))
-    @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(
-            mediaType = "application/json",
-            examples = {
-                    @ExampleObject(name = "TI0014", description = "입금 링크가 필요하지 않은 티켓일 때 발생합니다.",
-                            value = """
-                                    {"code": "TI0014", "message": "입금이 완료되었거나, 입금이 필요 없는 티켓입니다."}
+                                    {"code": "EV0001", "message": "해당 축제를 찾을 수 없습니다."}
                                     """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/EventApi.java
@@ -1,5 +1,7 @@
 package com.uket.app.ticket.api.controller;
 
+import com.uket.app.ticket.api.dto.response.AccountInfoResponse;
+import com.uket.app.ticket.api.dto.response.AccountResponse;
 import com.uket.app.ticket.api.dto.response.ShowResponse;
 import com.uket.app.ticket.api.dto.response.ReservationResponse;
 import com.uket.core.dto.response.ErrorResponse;
@@ -67,5 +69,34 @@ public interface EventApi {
 
             @PathVariable("reservationUserType")
             String userType
+    );
+
+    @GetMapping("/{id}/account")
+    @Operation(summary = "계좌 정보 조회 API", description = "축제에 대한 계좌 정보를 조회할 수 있습니다")
+    @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(name = "TI0009", description = "티켓의 아이디가 잘못된 경우 발생합니다.",
+                            value = """
+                                    {"code": "TI0009", "message": "해당 티켓을 찾을 수 없습니다. 티켓 아이디를 다시 확인해주세요."}
+                                    """
+                    )
+            }, schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(name = "TI0014", description = "입금 링크가 필요하지 않은 티켓일 때 발생합니다.",
+                            value = """
+                                    {"code": "TI0014", "message": "입금이 완료되었거나, 입금이 필요 없는 티켓입니다."}
+                                    """
+                    )
+            }, schema = @Schema(implementation = ErrorResponse.class)))
+    ResponseEntity<AccountResponse> getAccount(
+            @Parameter(hidden = true)
+            @LoginUserId
+            Long userId,
+
+            @PathVariable("id")
+            Long eventId
     );
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
@@ -144,11 +144,6 @@ public interface TicketApi {
                             value = """
                                     {"code": "TI0009", "message": "해당 티켓을 찾을 수 없습니다. 티켓 아이디를 다시 확인해주세요."}
                                     """
-                    ),
-                    @ExampleObject(name = "TI0015", description = "해당 이벤트에 설정된 입금 링크가 존재하지 않는 경우 발생합니다.",
-                            value = """
-                                    {"code": "TI0015", "message": "입금 링크가 존재하지 않습니다."}
-                                    """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
     @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
@@ -1,22 +1,19 @@
 package com.uket.app.ticket.api.controller;
 
+import com.uket.app.ticket.api.dto.response.AccountInfoResponse;
 import com.uket.app.ticket.api.dto.request.TicketingRequest;
 import com.uket.app.ticket.api.dto.response.CancelTicketResponse;
 import com.uket.app.ticket.api.dto.response.TicketingResponse;
 import com.uket.core.dto.response.ErrorResponse;
 import com.uket.domain.auth.config.userid.LoginUserId;
-import com.uket.domain.ticket.dto.CancelTicketDto;
-import com.uket.domain.ticket.dto.CheckTicketDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -138,7 +135,7 @@ public interface TicketApi {
         Long ticketId
     );
 
-    @GetMapping("/{id}/depositUrl")
+    @GetMapping("/{id}/accountInfo")
     @Operation(summary = "입금 링크 조회 API", description = "축제에 대한 입금 링크를 조회할 수 있습니다")
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
@@ -163,7 +160,7 @@ public interface TicketApi {
                                     """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))
-    ResponseEntity<String> getDepositUrl(
+    ResponseEntity<AccountInfoResponse> getAccountInfo(
         @Parameter(hidden = true)
         @LoginUserId
         Long userId,

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
@@ -136,7 +136,7 @@ public interface TicketApi {
     );
 
     @GetMapping("/{id}/accountInfo")
-    @Operation(summary = "입금 링크 조회 API", description = "축제에 대한 입금 링크를 조회할 수 있습니다")
+    @Operation(summary = "계좌 정보 조회 API", description = "축제에 대한 계좌 정보를 조회할 수 있습니다")
     @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
@@ -140,12 +140,26 @@ public interface TicketApi {
 
     @GetMapping("/{id}/depositUrl")
     @Operation(summary = "입금 링크 조회 API", description = "축제에 대한 입금 링크를 조회할 수 있습니다")
-    @ApiResponse(responseCode = "404", description = "BAD REQUEST", content = @Content(
+    @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
             mediaType = "application/json",
             examples = {
                     @ExampleObject(name = "TI0009", description = "티켓의 아이디가 잘못된 경우 발생합니다.",
                             value = """
                                     {"code": "TI0009", "message": "해당 티켓을 찾을 수 없습니다. 티켓 아이디를 다시 확인해주세요."}
+                                    """
+                    ),
+                    @ExampleObject(name = "TI0015", description = "해당 이벤트에 설정된 입금 링크가 존재하지 않는 경우 발생합니다.",
+                            value = """
+                                    {"code": "TI0015", "message": "입금 링크가 존재하지 않습니다."}
+                                    """
+                    )
+            }, schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(name = "TI0014", description = "입금 링크가 필요하지 않은 티켓일 때 발생합니다.",
+                            value = """
+                                    {"code": "TI0014", "message": "입금이 완료되었거나, 입금이 필요 없는 티켓입니다."}
                                     """
                     )
             }, schema = @Schema(implementation = ErrorResponse.class)))

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TicketApi.java
@@ -135,33 +135,4 @@ public interface TicketApi {
         Long ticketId
     );
 
-    @GetMapping("/{id}/accountInfo")
-    @Operation(summary = "계좌 정보 조회 API", description = "축제에 대한 계좌 정보를 조회할 수 있습니다")
-    @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
-            mediaType = "application/json",
-            examples = {
-                    @ExampleObject(name = "TI0009", description = "티켓의 아이디가 잘못된 경우 발생합니다.",
-                            value = """
-                                    {"code": "TI0009", "message": "해당 티켓을 찾을 수 없습니다. 티켓 아이디를 다시 확인해주세요."}
-                                    """
-                    )
-            }, schema = @Schema(implementation = ErrorResponse.class)))
-    @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(
-            mediaType = "application/json",
-            examples = {
-                    @ExampleObject(name = "TI0014", description = "입금 링크가 필요하지 않은 티켓일 때 발생합니다.",
-                            value = """
-                                    {"code": "TI0014", "message": "입금이 완료되었거나, 입금이 필요 없는 티켓입니다."}
-                                    """
-                    )
-            }, schema = @Schema(implementation = ErrorResponse.class)))
-    ResponseEntity<AccountInfoResponse> getAccountInfo(
-        @Parameter(hidden = true)
-        @LoginUserId
-        Long userId,
-
-        @PathVariable("id")
-        Long ticketId
-    );
-
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -1,10 +1,13 @@
 package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.EventApi;
+import com.uket.app.ticket.api.dto.response.AccountResponse;
 import com.uket.app.ticket.api.dto.response.ShowResponse;
 import com.uket.app.ticket.api.dto.response.ReservationResponse;
 import com.uket.domain.event.dto.ShowDto;
 import com.uket.domain.event.dto.ReservationDto;
+import com.uket.domain.event.entity.Account;
+import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.event.service.EventService;
 import com.uket.domain.event.service.ShowService;
@@ -43,5 +46,12 @@ public class EventController implements EventApi {
 
         ReservationResponse response = ReservationResponse.of(showName, reservations);
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<AccountResponse> getAccount(Long userId, Long eventId) {
+        Events event = eventService.findById(eventId);
+        AccountResponse accountResponse = AccountResponse.from(event.getAccount());
+        return ResponseEntity.ok(accountResponse);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -50,8 +50,9 @@ public class EventController implements EventApi {
 
     @Override
     public ResponseEntity<AccountResponse> getAccount(Long userId, Long eventId) {
-        Events event = eventService.findById(eventId);
-        AccountResponse accountResponse = AccountResponse.from(event.getAccount());
+        Account account = eventService.findAccountByEventId(eventId);
+        AccountResponse accountResponse = AccountResponse.from(account);
         return ResponseEntity.ok(accountResponse);
     }
+
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
@@ -2,12 +2,14 @@ package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.TicketApi;
 import com.uket.app.ticket.api.dto.request.TicketingRequest;
+import com.uket.app.ticket.api.dto.response.AccountInfoResponse;
 import com.uket.app.ticket.api.dto.response.CancelTicketResponse;
 import com.uket.app.ticket.api.dto.response.TicketingResponse;
 import com.uket.app.ticket.api.service.QRCodeService;
 import com.uket.app.ticket.api.service.TicketInfoService;
 import com.uket.app.ticket.api.service.TicketingService;
 import com.uket.domain.event.entity.Events;
+import com.uket.domain.ticket.dto.AccountInfoDto;
 import com.uket.domain.ticket.dto.CancelTicketDto;
 import com.uket.domain.ticket.dto.TicketDto;
 import com.uket.domain.ticket.entity.Ticket;
@@ -60,9 +62,10 @@ public class TicketController implements TicketApi {
     }
 
     @Override
-    public ResponseEntity<String> getDepositUrl(Long userId, Long ticketId) {
+    public ResponseEntity<AccountInfoResponse> getAccountInfo(Long userId, Long ticketId) {
         ticketService.checkTicketOwner(userId, ticketId);
-        String depositUrl = ticketService.getDepositUrlFromTicket(ticketId);
-        return ResponseEntity.ok(depositUrl);
+        AccountInfoDto accountInfoDto = ticketService.getAccountInfo(ticketId);
+        AccountInfoResponse accountInfoResponse = AccountInfoResponse.of(accountInfoDto);
+        return ResponseEntity.ok(accountInfoResponse);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TicketController.java
@@ -61,11 +61,4 @@ public class TicketController implements TicketApi {
         return ResponseEntity.ok(cancelTicketResponse);
     }
 
-    @Override
-    public ResponseEntity<AccountInfoResponse> getAccountInfo(Long userId, Long ticketId) {
-        ticketService.checkTicketOwner(userId, ticketId);
-        AccountInfoDto accountInfoDto = ticketService.getAccountInfo(ticketId);
-        AccountInfoResponse accountInfoResponse = AccountInfoResponse.of(accountInfoDto);
-        return ResponseEntity.ok(accountInfoResponse);
-    }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountInfoResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountInfoResponse.java
@@ -1,0 +1,11 @@
+package com.uket.app.ticket.api.dto.response;
+
+public record AccountInfoResponse(
+        String accountNumber,
+        String accountOwner,
+        String depositUrl
+) {
+    public static AccountInfoResponse of(String accountNumber, String accountOwner, String depositUrl) {
+        return new AccountInfoResponse(accountNumber, accountOwner, depositUrl);
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountInfoResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountInfoResponse.java
@@ -1,11 +1,16 @@
 package com.uket.app.ticket.api.dto.response;
 
+import com.uket.domain.ticket.dto.AccountInfoDto;
+
 public record AccountInfoResponse(
         String accountNumber,
         String accountOwner,
         String depositUrl
 ) {
-    public static AccountInfoResponse of(String accountNumber, String accountOwner, String depositUrl) {
-        return new AccountInfoResponse(accountNumber, accountOwner, depositUrl);
+    public static AccountInfoResponse of(AccountInfoDto accountInfoDto) {
+        String aN = accountInfoDto.accountNumber();
+        String aO = accountInfoDto.accountOwner();
+        String dU = accountInfoDto.depositUrl();
+        return new AccountInfoResponse(aN, aO, dU);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/AccountResponse.java
@@ -1,0 +1,20 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.event.entity.Account;
+import lombok.Builder;
+
+@Builder
+public record AccountResponse(
+        String accountNumber,
+        String accountOwner,
+        String depositUrl,
+        Integer ticketPrice
+) {
+    public static AccountResponse from(Account account) {
+        return AccountResponse.builder()
+                .accountNumber(account.getAccountNumber())
+                .accountOwner(account.getAccountOwner())
+                .depositUrl(account.getDepositUrl())
+                .build();
+    }
+}

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
     BEFORE_PAYMENT_TICKET(400,"TI0012","입금이 완료되지 않은 티켓입니다."),
     ALREADY_ENTER_TICKET(400,"TI0013","이미 입장이 완료된 티켓입니다."),
     NOT_BEFORE_PAYMENT_TICKET(400,"TI0014","입금이 완료되었거나, 입금이 필요 없는 티켓입니다."),
+    NOT_FOUND_DEPOSIT_URL(404,"TI0015","입금 링크가 존재하지 않습니다."),
 
     /**
      * QR Errors

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -81,8 +81,6 @@ public enum ErrorCode {
     NOT_FOUND_TICKET(404, "TI0011", "해당 사용자에 해당하는 티켓이 존재하지 않습니다."),
     BEFORE_PAYMENT_TICKET(400,"TI0012","입금이 완료되지 않은 티켓입니다."),
     ALREADY_ENTER_TICKET(400,"TI0013","이미 입장이 완료된 티켓입니다."),
-    NOT_BEFORE_PAYMENT_TICKET(400,"TI0014","입금이 완료되었거나, 입금이 필요 없는 티켓입니다."),
-    NOT_FOUND_DEPOSIT_URL(404,"TI0015","입금 링크가 존재하지 않습니다."),
 
     /**
      * QR Errors

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Account.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Account.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,30 +22,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Events extends BaseEntity {
+public class Account extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "event_id")
+    @Column(name = "account_id")
     private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "university_id")
-    private University university;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account_id")
-    private Account account;
-
-    private String name;
-    private LocalDate startDate;
-    private LocalDate endDate;
-    private String location;
     private String depositUrl;
     private String accountNumber;
     private String accountOwner;
+    private Integer ticketPrice;
 
-    public void updateUniversity(University university) {
-        this.university = university;
-    }
 }

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
@@ -38,7 +38,8 @@ public class Events extends BaseEntity {
     private LocalDate endDate;
     private String location;
     private String depositUrl;
-    private String accountDetail;
+    private String accountNumber;
+    private String accountOwner;
 
     public void updateUniversity(University university) {
         this.university = university;

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
@@ -38,6 +38,7 @@ public class Events extends BaseEntity {
     private LocalDate endDate;
     private String location;
     private String depositUrl;
+    private String accountDetail;
 
     public void updateUniversity(University university) {
         this.university = university;

--- a/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/entity/Events.java
@@ -42,9 +42,6 @@ public class Events extends BaseEntity {
     private LocalDate startDate;
     private LocalDate endDate;
     private String location;
-    private String depositUrl;
-    private String accountNumber;
-    private String accountOwner;
 
     public void updateUniversity(University university) {
         this.university = university;

--- a/domain/event-domain/src/main/java/com/uket/domain/event/repository/AccountRepository.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.uket.domain.event.repository;
+
+import com.uket.domain.event.entity.Account;
+import com.uket.domain.event.entity.Events;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/AccountService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/AccountService.java
@@ -1,0 +1,31 @@
+package com.uket.domain.event.service;
+
+import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Account;
+import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.enums.ReservationUserType;
+import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.repository.AccountRepository;
+import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.university.entity.University;
+import com.uket.domain.university.exception.UniversityException;
+import com.uket.domain.university.service.UniversityService;
+import com.uket.domain.user.entity.Users;
+import com.uket.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+
+    public Account findById(Long accountId) {
+        return accountRepository.findById(accountId)
+                .orElseThrow(() -> new EventException(ErrorCode.UNKNOWN_SERVER_ERROR));
+    }
+
+}

--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -1,9 +1,11 @@
 package com.uket.domain.event.service;
 
 import com.uket.core.exception.ErrorCode;
+import com.uket.domain.event.entity.Account;
 import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.enums.ReservationUserType;
 import com.uket.domain.event.exception.EventException;
+import com.uket.domain.event.repository.AccountRepository;
 import com.uket.domain.event.repository.EventRepository;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.exception.UniversityException;
@@ -22,6 +24,7 @@ public class EventService {
     private final EventRepository eventRepository;
     private final UniversityService universityService;
     private final UserService userService;
+    private final AccountRepository accountRepository;
 
     public Events findById(Long eventId) {
         return eventRepository.findById(eventId)
@@ -48,5 +51,11 @@ public class EventService {
             return ReservationUserType.TICKETING_STUDENT;
         }
         return ReservationUserType.TICKETING_ALL;
+    }
+
+    @Transactional(readOnly = true)
+    public Account findAccountByEventId(Long eventId) {
+        Events event = findById(eventId);
+        return event.getAccount();
     }
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/AccountInfoDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/AccountInfoDto.java
@@ -1,0 +1,11 @@
+package com.uket.domain.ticket.dto;
+
+public record AccountInfoDto(
+        String accountNumber,
+        String accountOwner,
+        String depositUrl
+) {
+    public static AccountInfoDto of(String accountNumber, String accountOwner, String depositUrl) {
+        return new AccountInfoDto(accountNumber, accountOwner, depositUrl);
+    }
+}

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/CheckTicketDto.java
@@ -26,6 +26,7 @@ public record CheckTicketDto(
     String eventName,
 
     Long ticketId,
+    Long eventId,
 
     Timestamp createdAt
 ) {
@@ -48,6 +49,7 @@ public record CheckTicketDto(
             .showName(show.getName())
             .eventName(event.getName())
             .ticketId(ticket.getId())
+            .eventId(ticket.getEvent().getId())
             .createdAt(ticket.getCreatedAt())
             .build();
     }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/TicketDto.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/dto/TicketDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 public record TicketDto(
         Long ticketId,
         Long userId,
+        Long eventId,
         String userName,
         TicketStatus status,
         String msg
@@ -17,6 +18,7 @@ public record TicketDto(
         return TicketDto.builder()
                 .ticketId(ticket.getId())
                 .userId(ticket.getUser().getId())
+                .eventId(ticket.getEvent().getId())
                 .userName(ticket.getUser().getName())
                 .status(ticket.getStatus())
                 .msg(ticket.getStatus().getMsg())

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -98,18 +98,4 @@ public class TicketService {
         return ticketRepository.save(updatedTicket);
     }
 
-    @Transactional(readOnly = true)
-    public AccountInfoDto getAccountInfo(Long ticketId) {
-        Ticket ticket = ticketRepository.findById(ticketId)
-                .orElseThrow(() -> new TicketException(ErrorCode.FAIL_TO_FIND_TICKET));
-        if(!ticket.getStatus().equals(TicketStatus.BEFORE_PAYMENT))
-            throw new TicketException(ErrorCode.NOT_BEFORE_PAYMENT_TICKET);
-
-        String accountNumber = ticket.getEvent().getAccountNumber();
-        String accountOwner = ticket.getEvent().getAccountOwner();
-        String depositUrl = ticket.getEvent().getDepositUrl();
-
-        return AccountInfoDto.of(accountNumber, accountOwner, depositUrl);
-    }
-
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -3,6 +3,7 @@ package com.uket.domain.ticket.service;
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.entity.Reservation;
 import com.uket.domain.event.service.ReservationService;
+import com.uket.domain.ticket.dto.AccountInfoDto;
 import com.uket.domain.ticket.dto.CancelTicketDto;
 import com.uket.domain.ticket.dto.CreateTicketDto;
 import com.uket.domain.ticket.entity.Ticket;
@@ -98,17 +99,17 @@ public class TicketService {
     }
 
     @Transactional(readOnly = true)
-    public String getDepositUrlFromTicket(Long ticketId) {
+    public AccountInfoDto getAccountInfo(Long ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new TicketException(ErrorCode.FAIL_TO_FIND_TICKET));
         if(!ticket.getStatus().equals(TicketStatus.BEFORE_PAYMENT))
             throw new TicketException(ErrorCode.NOT_BEFORE_PAYMENT_TICKET);
 
+        String accountNumber = ticket.getEvent().getAccountNumber();
+        String accountOwner = ticket.getEvent().getAccountOwner();
         String depositUrl = ticket.getEvent().getDepositUrl();
-        if(depositUrl==null || depositUrl.isEmpty())
-            throw new TicketException(ErrorCode.NOT_FOUND_DEPOSIT_URL);
 
-        return depositUrl;
+        return AccountInfoDto.of(accountNumber, accountOwner, depositUrl);
     }
 
 }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -103,7 +103,12 @@ public class TicketService {
                 .orElseThrow(() -> new TicketException(ErrorCode.FAIL_TO_FIND_TICKET));
         if(!ticket.getStatus().equals(TicketStatus.BEFORE_PAYMENT))
             throw new TicketException(ErrorCode.NOT_BEFORE_PAYMENT_TICKET);
-        return ticket.getEvent().getDepositUrl();
+
+        String depositUrl = ticket.getEvent().getDepositUrl();
+        if(depositUrl==null || depositUrl.isEmpty())
+            throw new TicketException(ErrorCode.NOT_FOUND_DEPOSIT_URL);
+
+        return depositUrl;
     }
 
 }


### PR DESCRIPTION
# 📌 개요
### 명세 및 예외처리
- 입금 링크 제공 API에 대한 명세 및 예외처리를 추가했습니다.
### 계좌 정보 제공
- 입금 링크에 더해 계좌 정보(계좌 번호, 예금주) 정보를 추가적으로 제공하도록 했습니다.

# 💻 작업사항
### 명세 및 예외처리
- depositUrl이 존재하지 않는 경우, NOT_FOUND_DEPOSIT_URL에러를 throw하는 예외처리를 추가했습니다
- getDepositUrl API에 대한 400과 404인 경우의 명세를 올바르게 수정/추가 했습니다.
### 계좌 정보 제공
- 기존 TicketController/TicketService의 getDepositUrl를, getAccountInfo로 변경하였습니다.
- Events 엔티티에 accountNumber, accountOwner 필드를 추가했습니다.
- 기존 TicketService에서 depositUrl만 제공하던 형태에서 accountNumber, accountOwner도 함께 제공하는 형태로 변경했습니다.
- 제공하는 데이터가 많아짐에 따라 dto, response dto를 추가했습니다.
- 기존 TicketService에서 depositUrl이 존재하지 않는 경우 예외를 던지던 것을 json에 null 값을 보내도록 수정했습니다.
- 이에 따라 depositUrl이 존재하지 않는 경우의 404 응답에 대한 명세를 제거했습니다.

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
### 명세 및 예외처리
- LazyInitializationException의 경우는 이미 해결된 것으로 확인했는데, 제가 잘 못 이해한 것이라면 알려주시기 바랍니다!!(맞다는 것으로 확인했습니다 by 민재형)
### 계좌 정보 제공
- 이전에 입금 링크를 추가하면서도 했던 고민인데, 이번에 계좌 정보를 추가하면서도 똑같은 고민을 하게 되어 여러분의 의견을 묻고 싶어졌습니다.<br>
현재 Ticket 엔티티는 예약 목록 정보에 가깝고, 티켓의 판매 정보를 저장하는 엔티티는 따로 없습니다.
어차피 티켓 종류의 구분이 아직 없으므로 티켓의 판매 정보를 Events에 다 몰아넣는 형태가 되었습니다.<br>
여기서 API를 어떤 도메인으로 뚫어야 하는 지가 고민입니다.
현재 티켓의 판매 정보를 제공해야하는 화면이 1. 티켓 상세 / 2. 티켓 예매 완료 이렇게 2가지 입니다.<br>
둘 모두 티켓 아이디를 통해서 조회하는 것이 더 편할 것이라고 생각해서 TicketController에 API를 추가했던 것인데,
(티켓 상세의 경우는 event id로는 조회가 불가능하기도 함)
추후에 공연/축제 정보 화면에서 티켓 판매 정보를 조회하는 상황이 오게 되면, 그때는 무조건 event Id를 이용해야할 것으로 보입니다.<br>
이런 경우 그냥 event 도메인에도 API를 뚫어주면 되는 걸까요??
애초에 Event 엔티티에 포함된 정보를 제공하는 거라 ticket 도메인에 뚫어주면 안되는 것이었을까요?
- accountInfoResponse를 구성하던 중 값이 몇개 비어버리게 될 수도 있을터인데 이럴 때 예외처리와 명세는 어떻게 작성하는 것이 적합할 지 궁금합니다.