### PR TITLE
[SVR-58] 공연 목록 조회 시 시작, 종료 일자 반환하도록 수정

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/UniversityApi.java
@@ -1,5 +1,6 @@
 package com.uket.app.ticket.api.controller;
 
+import com.uket.app.ticket.api.dto.response.ActiveUniversitiesResponse;
 import com.uket.app.ticket.api.dto.response.CertifiableUniversityResponse;
 import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
 import com.uket.app.ticket.api.dto.response.ListResponse;
@@ -26,7 +27,7 @@ public interface UniversityApi {
 
     @GetMapping
     @Operation(summary = "전체 대학 조회 API", description = "현재 진행중인 축제가 있는 모든 대학을 조회합니다.")
-    ResponseEntity<ListResponse<UniversityDto>> getUniversities();
+    ResponseEntity<ListResponse<ActiveUniversitiesResponse>> getUniversities();
 
     @GetMapping(value = "/{id}/event")
     @Operation(summary = "대학별 진행중인 축제 조회 API", description = "대학별 진행중인 축제를 조회합니다.")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UniversityController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/UniversityController.java
@@ -1,6 +1,7 @@
 package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.UniversityApi;
+import com.uket.app.ticket.api.dto.response.ActiveUniversitiesResponse;
 import com.uket.app.ticket.api.dto.response.CertifiableUniversityResponse;
 import com.uket.app.ticket.api.dto.response.CurrentEventResponse;
 import com.uket.app.ticket.api.dto.response.ListResponse;
@@ -25,13 +26,13 @@ public class UniversityController implements UniversityApi {
     private final S3ImageUrlConverter s3ImageUrlConverter;
 
     @Override
-    public ResponseEntity<ListResponse<UniversityDto>> getUniversities() {
+    public ResponseEntity<ListResponse<ActiveUniversitiesResponse>> getUniversities() {
 
         LocalDate now = LocalDate.now();
 
-        List<UniversityDto> universities = s3ImageUrlConverter.getUniversitiesByDate(now);
+        List<ActiveUniversitiesResponse> universities = s3ImageUrlConverter.getUniversitiesByDate(now);
 
-        ListResponse<UniversityDto> response = ListResponse.from(universities);
+        ListResponse<ActiveUniversitiesResponse> response = ListResponse.from(universities);
         return ResponseEntity.ok(response);
     }
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ActiveUniversitiesResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ActiveUniversitiesResponse.java
@@ -1,0 +1,23 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.university.dto.UniversityDto;
+import com.uket.domain.university.entity.University;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ActiveUniversitiesResponse(
+        Long id,
+        String name,
+        String logoUrl,
+        LocalDateTime startDateTime
+) {
+    public static UniversityDto from(University university) {
+        return UniversityDto.builder()
+                .id(university.getId())
+                .name(university.getName())
+                .logoUrl(university.getLogoPath())
+                .build();
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
@@ -1,13 +1,19 @@
 package com.uket.app.ticket.api.util;
 
+import com.uket.app.ticket.api.dto.response.ActiveUniversitiesResponse;
 import com.uket.app.ticket.api.service.UniversityEventService;
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
 import com.uket.domain.event.dto.BannerDto;
+import com.uket.domain.event.dto.ShowDto;
 import com.uket.domain.event.entity.Banner;
 import com.uket.domain.event.entity.Events;
 import com.uket.domain.event.repository.BannerRepository;
+import com.uket.domain.event.service.ShowService;
 import com.uket.domain.university.dto.UniversityDto;
 import com.uket.modules.aws.s3.service.S3Service;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class S3ImageUrlConverter {
 
     private final S3Service s3Service;
+    private final ShowService showService;
     private final UniversityEventService universityEventService;
     private final BannerRepository bannerRepository;
 
@@ -31,7 +38,7 @@ public class S3ImageUrlConverter {
                 }).toList();
     }
 
-    public List<UniversityDto> getUniversitiesByDate(LocalDate date) {
+    public List<ActiveUniversitiesResponse> getUniversitiesByDate(LocalDate date) {
 
         List<UniversityDto> universities = universityEventService.getUniversitiesByDate(date);
 
@@ -39,13 +46,15 @@ public class S3ImageUrlConverter {
                 .map(universityDto -> {
                     String logoUrl = s3Service.getUniversityLogo(universityDto.logoUrl());
                     Events currentEvent = universityEventService.getCurrentEventOfUniversity(universityDto.id());
+                    ShowDto show = showService.findByEventId(currentEvent.getId()).stream()
+                            .min(Comparator.comparing(ShowDto::startDate))
+                            .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_SHOW));
 
-                    return UniversityDto.builder()
+                    return ActiveUniversitiesResponse.builder()
                             .id(universityDto.id())
                             .name(universityDto.name())
                             .logoUrl(logoUrl)
-                            .startDate(currentEvent.getStartDate())
-                            .endDate(currentEvent.getEndDate())
+                            .startDateTime(show.startDate().toLocalDateTime())
                             .build();
                 }).toList();
     }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
@@ -38,7 +38,15 @@ public class S3ImageUrlConverter {
         return universities.stream()
                 .map(universityDto -> {
                     String logoUrl = s3Service.getUniversityLogo(universityDto.logoUrl());
-                    return UniversityDto.updateLogoUrl(universityDto, logoUrl);
+                    Events currentEvent = universityEventService.getCurrentEventOfUniversity(universityDto.id());
+
+                    return UniversityDto.builder()
+                            .id(universityDto.id())
+                            .name(universityDto.name())
+                            .logoUrl(logoUrl)
+                            .startDate(currentEvent.getStartDate())
+                            .endDate(currentEvent.getEndDate())
+                            .build();
                 }).toList();
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
@@ -13,6 +13,7 @@ import com.uket.domain.event.service.ShowService;
 import com.uket.domain.university.dto.UniversityDto;
 import com.uket.modules.aws.s3.service.S3Service;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,16 +47,21 @@ public class S3ImageUrlConverter {
                 .map(universityDto -> {
                     String logoUrl = s3Service.getUniversityLogo(universityDto.logoUrl());
                     Events currentEvent = universityEventService.getCurrentEventOfUniversity(universityDto.id());
-                    ShowDto show = showService.findByEventId(currentEvent.getId()).stream()
-                            .min(Comparator.comparing(ShowDto::startDate))
-                            .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_SHOW));
+                    LocalDateTime firstShowStartDateTime = getFirstShowStartDateTime(currentEvent);
 
                     return ActiveUniversitiesResponse.builder()
                             .id(universityDto.id())
                             .name(universityDto.name())
                             .logoUrl(logoUrl)
-                            .startDateTime(show.startDate().toLocalDateTime())
+                            .startDateTime(firstShowStartDateTime)
                             .build();
                 }).toList();
+    }
+
+    private LocalDateTime getFirstShowStartDateTime(Events currentEvent) {
+        return showService.findByEventId(currentEvent.getId()).stream()
+                .min(Comparator.comparing(ShowDto::startDate))
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_SHOW))
+                .startDate().toLocalDateTime();
     }
 }

--- a/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UniversityControllerTest.java
+++ b/application/ticket-app-api/src/test/java/com/uket/app/ticket/api/controller/UniversityControllerTest.java
@@ -8,7 +8,9 @@ import com.uket.app.ticket.api.service.UserRegisterService;
 import com.uket.core.exception.ErrorCode;
 import com.uket.domain.auth.dto.response.AuthToken;
 import com.uket.domain.event.entity.Events;
+import com.uket.domain.event.entity.Shows;
 import com.uket.domain.event.repository.EventRepository;
+import com.uket.domain.event.repository.ShowRepository;
 import com.uket.domain.university.entity.University;
 import com.uket.domain.university.repository.UniversityRepository;
 import com.uket.domain.user.dto.CreateUserDetailsDto;
@@ -20,6 +22,7 @@ import com.uket.domain.user.service.UserService;
 import com.uket.modules.jwt.constants.JwtValues;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +54,8 @@ class UniversityControllerTest {
     UniversityRepository universityRepository;
     @Autowired
     EventRepository eventRepository;
+    @Autowired
+    ShowRepository showRepository;
 
     Users user;
     String accessToken;
@@ -94,6 +99,16 @@ class UniversityControllerTest {
                         .endDate(LocalDate.now())
                         .build()
         );
+
+        Shows show = showRepository.save(
+                Shows.builder()
+                        .startDate(LocalDateTime.now())
+                        .endDate(LocalDateTime.now())
+                        .ticketingDate(LocalDateTime.now())
+                        .event(event)
+                        .build()
+        );
+
         University konkuk = universityRepository.save(
                 University.builder()
                         .name(UNIVERSITY_KONKUK)

--- a/domain/event-domain/src/main/java/com/uket/domain/event/repository/EventRepositoryCustomImpl.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/repository/EventRepositoryCustomImpl.java
@@ -25,7 +25,9 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                 .select(Projections.constructor(UniversityDto.class,
                         university.id,
                         university.name,
-                        university.logoPath
+                        university.logoPath,
+                        events.startDate,
+                        events.endDate
                 ))
                 .from(events)
                 .where(events.startDate.loe(date),

--- a/domain/university-domain/src/main/java/com/uket/domain/university/dto/UniversityDto.java
+++ b/domain/university-domain/src/main/java/com/uket/domain/university/dto/UniversityDto.java
@@ -1,28 +1,22 @@
 package com.uket.domain.university.dto;
 
 import com.uket.domain.university.entity.University;
+import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record UniversityDto(
         Long id,
         String name,
-        String logoUrl
+        String logoUrl,
+        LocalDate startDate,
+        LocalDate endDate
 ) {
-
     public static UniversityDto from(University university) {
         return UniversityDto.builder()
                 .id(university.getId())
                 .name(university.getName())
                 .logoUrl(university.getLogoPath())
-                .build();
-    }
-
-    public static UniversityDto updateLogoUrl(UniversityDto universityDto, String logoUrl) {
-        return UniversityDto.builder()
-                .id(universityDto.id())
-                .name(universityDto.name())
-                .logoUrl(logoUrl)
                 .build();
     }
 }


### PR DESCRIPTION
# 📌 개요
- 공연 목록 조회 시 시작, 종료 일자 반환하도록 수정했습니다.
- 피그마에는 시작 일자 및 시작 시간이 보여지도록 되어 있는데 제 생각엔 기존 Event라는게 여러 일자를 포함하는 큰 개념이기에 대학 축제와 범용적으로 사용하기 위해선 시작,종료 일자를 보여주는게 맞다고 생각해 이렇게 구성했습니다.
- 다른 의견 있다면 말씀주세용! 

# 💻 작업사항
- [x] 공연 목록 조회 시 시작, 종료 일자 반환

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- N/A
