### PR TITLE
[SVR-61] 계좌정보 lazy loading 문제 수정

### DIFF
--- a/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
+++ b/domain/event-domain/src/main/java/com/uket/domain/event/service/EventService.java
@@ -13,6 +13,7 @@ import com.uket.domain.university.service.UniversityService;
 import com.uket.domain.user.entity.Users;
 import com.uket.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +57,9 @@ public class EventService {
     @Transactional(readOnly = true)
     public Account findAccountByEventId(Long eventId) {
         Events event = findById(eventId);
-        return event.getAccount();
+        Account account = event.getAccount();
+        Hibernate.initialize(account);
+
+        return account;
     }
 }


### PR DESCRIPTION
# 📌 개요
- lazy loading으로 조회되던 계좌정보가 초기화되지 않아 오류가 발생했습니다.

# 💻 작업사항
- 트랜젝션 안쪽에서 강제 초기화 시켰습니다.

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- N/A
