### PR TITLE
[SVR-62]  유저 탈퇴시 예매 가능 티켓 수 증가

### DIFF
--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/repository/TicketRepository.java
@@ -8,6 +8,8 @@ import com.uket.domain.user.entity.Users;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TicketRepository extends JpaRepository<Ticket,Long> {
 
@@ -28,5 +30,9 @@ public interface TicketRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findAllByUserIdAndStatusNot(Long userId, TicketStatus status);
 
     void deleteAllByUserId(Long userId);
+
+    @Query("SELECT t FROM Ticket t JOIN FETCH t.reservation r WHERE t.user.id = :userId AND t.status <> :status")
+    List<Ticket> findAllByUserIdAndStatusNotWithReservation(@Param("userId") Long userId, @Param("status") TicketStatus status);
+
 }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -79,6 +79,10 @@ public class TicketService {
 
     @Transactional
     public void deleteAllUserTickets(Long userId) {
+        List<Ticket> tickets = ticketRepository.findAllByUserIdAndStatusNot(userId, TicketStatus.RESERVATION_CANCEL);
+        for(Ticket ticket : tickets) {
+            this.decreaseReservedCount(ticket.getId());
+        }
         ticketRepository.deleteAllByUserId(userId);
     }
 

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -81,7 +81,7 @@ public class TicketService {
     public void deleteAllUserTickets(Long userId) {
         List<Ticket> tickets = ticketRepository.findAllByUserIdAndStatusNot(userId, TicketStatus.RESERVATION_CANCEL);
         for(Ticket ticket : tickets) {
-            this.decreaseReservedCount(ticket.getId());
+            this.decreaseReservedCount(ticket.getReservation().getId());
         }
         ticketRepository.deleteAllByUserId(userId);
     }

--- a/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
+++ b/domain/ticket-domain/src/main/java/com/uket/domain/ticket/service/TicketService.java
@@ -79,7 +79,7 @@ public class TicketService {
 
     @Transactional
     public void deleteAllUserTickets(Long userId) {
-        List<Ticket> tickets = ticketRepository.findAllByUserIdAndStatusNot(userId, TicketStatus.RESERVATION_CANCEL);
+        List<Ticket> tickets = ticketRepository.findAllByUserIdAndStatusNotWithReservation(userId, TicketStatus.RESERVATION_CANCEL);
         for(Ticket ticket : tickets) {
             this.decreaseReservedCount(ticket.getReservation().getId());
         }


### PR DESCRIPTION
# 📌 개요
- 유저 탈퇴 시에 예매된 티켓의 예매 가능 수를 늘리도록 구현했습니다.

# 💻 작업사항
- [x] 유저 탈퇴 시 해당 유저의 티켓에 해당하는 예약의 예매 수 증가

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- 
