### PR TITLE
[SVR-65] 약관 조회 API 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0703kyj @sam971114
+* @0703kyj @sam971114 @nonaninona

--- a/application/ticket-app-api/build.gradle
+++ b/application/ticket-app-api/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation project(":domain:university-domain")
 	implementation project(":domain:event-domain")
 	implementation project(":domain:ticket-domain")
+	implementation project(":domain:terms-domain")
 
 	implementation project(":modules:jwt-provider")
 	implementation project(":modules:aws-s3")

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
@@ -1,0 +1,28 @@
+package com.uket.app.ticket.api.controller;
+
+import com.uket.app.ticket.api.dto.response.ListResponse;
+import com.uket.app.ticket.api.dto.response.TermsResponse;
+import com.uket.domain.auth.config.userid.LoginUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "약관 API", description = "약관 관련 API")
+@RestController
+@SecurityRequirement(name = "JWT")
+@ApiResponse(responseCode = "200", description = "OK")
+public interface TermsApi {
+
+    @GetMapping("/api/v1/terms")
+    @Operation(summary = "약관 목록 조회 API", description = "회원가입 시 필요한 약관 목록을 조회할 수 있습니다.")
+    ResponseEntity<ListResponse<TermsResponse>> getTerms(
+            @LoginUserId
+            @Parameter(hidden = true)
+            Long userId
+    );
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
@@ -1,6 +1,8 @@
 package com.uket.app.ticket.api.controller;
 
+import com.uket.app.ticket.api.dto.request.TermsAgreementRequest;
 import com.uket.app.ticket.api.dto.response.ListResponse;
+import com.uket.app.ticket.api.dto.response.TermsAgreementResponse;
 import com.uket.app.ticket.api.dto.response.TermsResponse;
 import com.uket.domain.auth.config.userid.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,8 +10,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "약관 API", description = "약관 관련 API")
@@ -24,5 +29,16 @@ public interface TermsApi {
             @LoginUserId
             @Parameter(hidden = true)
             Long userId
+    );
+
+    @PostMapping("/api/v1/terms/agreement")
+    @Operation(summary = "약관 동의 API", description = "회원가입 시 약관 동의를 할 수 있습니다.")
+    ResponseEntity<ListResponse<TermsAgreementResponse>> agreeTerms(
+            @LoginUserId
+            @Parameter(hidden = true)
+            Long userId,
+
+            @RequestBody
+            List<TermsAgreementRequest> requests
     );
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TermsController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TermsController.java
@@ -1,9 +1,13 @@
 package com.uket.app.ticket.api.controller.impl;
 
 import com.uket.app.ticket.api.controller.TermsApi;
+import com.uket.app.ticket.api.dto.request.TermsAgreementRequest;
 import com.uket.app.ticket.api.dto.response.ListResponse;
+import com.uket.app.ticket.api.dto.response.TermsAgreementResponse;
 import com.uket.app.ticket.api.dto.response.TermsResponse;
+import com.uket.app.ticket.api.service.TermsAgreementService;
 import com.uket.domain.terms.entity.Terms;
+import com.uket.domain.terms.entity.TermsSign;
 import com.uket.domain.terms.service.DocumentService;
 import com.uket.domain.terms.service.TermsService;
 import com.uket.domain.terms.service.TermsSignService;
@@ -20,6 +24,7 @@ public class TermsController implements TermsApi {
     private final TermsService termsService;
     private final TermsSignService termsSignService;
     private final DocumentService documentService;
+    private final TermsAgreementService termsAgreementService;
 
     @Override
     public ResponseEntity<ListResponse<TermsResponse>> getTerms(Long userId) {
@@ -30,6 +35,16 @@ public class TermsController implements TermsApi {
         List<TermsResponse> termsResponses = getTermsResponse(activeTerms, termsSignMap, linkMap);
 
         return ResponseEntity.ok(ListResponse.from(termsResponses));
+    }
+
+    @Override
+    public ResponseEntity<ListResponse<TermsAgreementResponse>> agreeTerms(Long userId, List<TermsAgreementRequest> requests) {
+        List<TermsSign> termsSigns = termsAgreementService.agreeTerms(userId, requests);
+        List<TermsAgreementResponse> termsAgreementResponse = termsSigns.stream()
+                .map(TermsAgreementResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ListResponse.from(termsAgreementResponse));
     }
 
     private List<Long> getTermsIds(List<Terms> activeTerms) {

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TermsController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/TermsController.java
@@ -1,0 +1,56 @@
+package com.uket.app.ticket.api.controller.impl;
+
+import com.uket.app.ticket.api.controller.TermsApi;
+import com.uket.app.ticket.api.dto.response.ListResponse;
+import com.uket.app.ticket.api.dto.response.TermsResponse;
+import com.uket.domain.terms.entity.Terms;
+import com.uket.domain.terms.service.DocumentService;
+import com.uket.domain.terms.service.TermsService;
+import com.uket.domain.terms.service.TermsSignService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class TermsController implements TermsApi {
+
+    private final TermsService termsService;
+    private final TermsSignService termsSignService;
+    private final DocumentService documentService;
+
+    @Override
+    public ResponseEntity<ListResponse<TermsResponse>> getTerms(Long userId) {
+        List<Terms> activeTerms = termsService.findAllActive();
+
+        Map<Long, Boolean> termsSignMap = termsSignService.getTermsSignMap(userId, getTermsIds(activeTerms));
+        Map<Long, String> linkMap = documentService.getLinkMap(getDocumentNos(activeTerms));
+        List<TermsResponse> termsResponses = getTermsResponse(activeTerms, termsSignMap, linkMap);
+
+        return ResponseEntity.ok(ListResponse.from(termsResponses));
+    }
+
+    private List<Long> getTermsIds(List<Terms> activeTerms) {
+        return activeTerms.stream().map(Terms::getId).toList();
+    }
+
+    private List<Long> getDocumentNos(List<Terms> activeTerms) {
+        return activeTerms.stream().map(Terms::getDocumentNo).toList();
+    }
+
+    private List<TermsResponse> getTermsResponse(
+            List<Terms> activeTerms,
+            Map<Long, Boolean> termsSignMap,
+            Map<Long, String> termsLinkMap
+    ) {
+        return activeTerms.stream()
+                .map(terms -> TermsResponse.of(
+                        terms,
+                        termsSignMap.getOrDefault(terms.getId(), false),
+                        termsLinkMap.get(terms.getDocumentNo())
+                ))
+                .toList();
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/TermsAgreementRequest.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/request/TermsAgreementRequest.java
@@ -1,0 +1,6 @@
+package com.uket.app.ticket.api.dto.request;
+
+public record TermsAgreementRequest(
+        Long termId,
+        Boolean isAgreed
+) { }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/TermsAgreementResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/TermsAgreementResponse.java
@@ -1,0 +1,12 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.terms.entity.TermsSign;
+
+public record TermsAgreementResponse(
+        Long termId,
+        Boolean isAgreed
+) {
+    public static TermsAgreementResponse from(TermsSign termsSign){
+        return new TermsAgreementResponse(termsSign.getTermsId(), termsSign.getIsAgreed());
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/TermsResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/TermsResponse.java
@@ -1,0 +1,25 @@
+package com.uket.app.ticket.api.dto.response;
+
+import com.uket.domain.terms.entity.Terms;
+import com.uket.domain.terms.entity.TermsType;
+import lombok.Builder;
+
+@Builder
+public record TermsResponse(
+        Long termsId,
+        String name,
+        TermsType type,
+        String link,
+        Boolean isAgreed
+) {
+
+    public static TermsResponse of(Terms terms, Boolean isAgreed, String link){
+        return TermsResponse.builder()
+                .termsId(terms.getId())
+                .name(terms.getName())
+                .type(terms.getType())
+                .link(link)
+                .isAgreed(isAgreed)
+                .build();
+    }
+}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/TermsAgreementService.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/service/TermsAgreementService.java
@@ -1,0 +1,34 @@
+package com.uket.app.ticket.api.service;
+
+import com.uket.app.ticket.api.dto.request.TermsAgreementRequest;
+import com.uket.domain.terms.entity.Terms;
+import com.uket.domain.terms.entity.TermsSign;
+import com.uket.domain.terms.service.TermsService;
+import com.uket.domain.terms.service.TermsSignService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermsAgreementService {
+
+    private final TermsService termsService;
+    private final TermsSignService termsSignService;
+
+    @Transactional
+    public List<TermsSign> agreeTerms(Long userId, List<TermsAgreementRequest> requests){
+        List<TermsSign> termsSigns = requests.stream().map(request -> {
+            Long termsId = request.termId();
+            Boolean isAgreed = request.isAgreed();
+
+            Terms term = termsService.findById(termsId);
+            term.checkMandatory(isAgreed);
+
+            return isAgreed ? TermsSign.agree(userId, termsId) : TermsSign.agreeNot(userId, termsId);
+        }).toList();
+
+        return termsSignService.saveAll(termsSigns);
+    }
+}

--- a/core/src/main/java/com/uket/core/exception/ErrorCode.java
+++ b/core/src/main/java/com/uket/core/exception/ErrorCode.java
@@ -83,6 +83,12 @@ public enum ErrorCode {
     ALREADY_ENTER_TICKET(400,"TI0013","이미 입장이 완료된 티켓입니다."),
 
     /**
+     * Terms Errors
+     */
+    NOT_FOUND_TERMS(404, "TE0001", "약관을 찾을 수 없습니다."),
+    NOT_VALID_TERMS_AGREEMENT(400, "TE0002", "필수 문서는 동의가 필수입니다."),
+
+    /**
      * QR Errors
      */
     NOT_QR_TOKEN(400, "QR0001", "QR과 관련없는 다른 유형의 토큰이 입력되었습니다."),

--- a/domain/terms-domain/build.gradle
+++ b/domain/terms-domain/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    implementation project(":domain:core-domain")
+    implementation project(":domain:user-domain")
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+tasks.named('bootJar') {
+    enabled = false
+}
+
+tasks.named('jar') {
+    enabled = true
+}

--- a/domain/terms-domain/build.gradle
+++ b/domain/terms-domain/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     implementation project(":domain:core-domain")
-    implementation project(":domain:user-domain")
 }
 
 tasks.named('test') {

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Document.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Document.java
@@ -1,0 +1,36 @@
+package com.uket.domain.terms.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Document {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "document_no")
+    private Long documentNo;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "link")
+    private String link;
+
+    @Column(name = "version")
+    private Long version;
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Document.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Document.java
@@ -1,5 +1,6 @@
 package com.uket.domain.terms.entity;
 
+import com.uket.domain.core.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Document {
+public class Document extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Terms.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Terms.java
@@ -1,0 +1,42 @@
+package com.uket.domain.terms.entity;
+
+
+import com.uket.domain.core.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Terms extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private TermsType type;
+
+    @JoinColumn(name = "documnet_no")
+    private Long documentNo;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Terms.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/Terms.java
@@ -1,6 +1,8 @@
 package com.uket.domain.terms.entity;
 
 
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
 import com.uket.domain.core.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -39,4 +41,14 @@ public class Terms extends BaseEntity {
 
     @Column(name = "is_active")
     private Boolean isActive;
+
+    public void checkMandatory(Boolean isAgreed) {
+        if (type != TermsType.MANDATORY) {
+            return;
+        }
+
+        if(Boolean.FALSE.equals(isAgreed)){
+            throw new BaseException(ErrorCode.NOT_VALID_TERMS_AGREEMENT);
+        }
+    }
 }

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
@@ -36,4 +36,22 @@ public class TermsSign extends BaseEntity {
 
     @Column(name = "agreed_at")
     private LocalDateTime agreedAt;
+
+    public static TermsSign agree(Long userId, Long termsId){
+        return TermsSign.builder()
+                .userId(userId)
+                .termsId(termsId)
+                .isAgreed(true)
+                .agreedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static TermsSign agreeNot(Long userId, Long termsId){
+        return TermsSign.builder()
+                .userId(userId)
+                .termsId(termsId)
+                .isAgreed(false)
+                .agreedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
@@ -1,6 +1,7 @@
 package com.uket.domain.terms.entity;
 
 
+import com.uket.domain.core.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TermsSign {
+public class TermsSign extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsSign.java
@@ -1,0 +1,38 @@
+package com.uket.domain.terms.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermsSign {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "terms_id")
+    private Long termsId;
+
+    @Column(name = "is_agreed")
+    private Boolean isAgreed;
+
+    @Column(name = "agreed_at")
+    private LocalDateTime agreedAt;
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsType.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/entity/TermsType.java
@@ -1,0 +1,5 @@
+package com.uket.domain.terms.entity;
+
+public enum TermsType {
+    MANDATORY, OPTIONAL
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/DocumentRepository.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/DocumentRepository.java
@@ -1,8 +1,22 @@
 package com.uket.domain.terms.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.uket.domain.terms.entity.Document;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
+    @Query("""
+        SELECT d
+        FROM Document d
+        WHERE d.documentNo IN :documentNos
+          AND d.version = (
+              SELECT MAX(subD.version)
+              FROM Document subD
+              WHERE subD.documentNo = d.documentNo
+          )
+    """)
+    List<Document> findLatestDocumentsByDocumentNos(@Param("documentNos") List<Long> documentNos);
 }

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/DocumentRepository.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/DocumentRepository.java
@@ -1,0 +1,8 @@
+package com.uket.domain.terms.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.uket.domain.terms.entity.Document;
+
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/TermsRepository.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/TermsRepository.java
@@ -1,0 +1,10 @@
+package com.uket.domain.terms.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.uket.domain.terms.entity.Terms;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    List<Terms> findAllByIsActiveTrue();
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/TermsSignRepository.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/repository/TermsSignRepository.java
@@ -1,0 +1,26 @@
+package com.uket.domain.terms.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.uket.domain.terms.entity.TermsSign;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TermsSignRepository extends JpaRepository<TermsSign, Long> {
+
+    @Query("""
+        SELECT ts
+        FROM TermsSign ts
+        WHERE ts.userId = :userId
+          AND ts.termsId IN :termsIds
+          AND ts.agreedAt = (
+              SELECT MAX(subTs.agreedAt)
+              FROM TermsSign subTs
+              WHERE subTs.termsId = ts.termsId AND subTs.userId = ts.userId
+          )
+    """)
+    List<TermsSign> findLatestByUserIdAndTermsIds(
+            @Param("userId") Long userId,
+            @Param("termsIds") List<Long> termsIds
+    );
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/service/DocumentService.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/service/DocumentService.java
@@ -1,0 +1,23 @@
+package com.uket.domain.terms.service;
+
+import com.uket.domain.terms.entity.Document;
+import com.uket.domain.terms.repository.DocumentRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentService {
+
+    private final DocumentRepository documentRepository;
+
+    @Transactional(readOnly = true)
+    public Map<Long, String> getLinkMap(List<Long> documentNos) {
+        return documentRepository.findLatestDocumentsByDocumentNos(documentNos).stream()
+                .collect(Collectors.toMap(Document::getDocumentNo, Document::getLink));
+    }
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsService.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsService.java
@@ -1,5 +1,7 @@
 package com.uket.domain.terms.service;
 
+import com.uket.core.exception.BaseException;
+import com.uket.core.exception.ErrorCode;
 import com.uket.domain.terms.entity.Terms;
 import com.uket.domain.terms.repository.TermsRepository;
 import java.util.List;
@@ -16,5 +18,11 @@ public class TermsService {
     @Transactional(readOnly = true)
     public List<Terms> findAllActive() {
         return termsRepository.findAllByIsActiveTrue();
+    }
+
+    @Transactional(readOnly = true)
+    public Terms findById(Long termsId) {
+        return termsRepository.findById(termsId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_TERMS));
     }
 }

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsService.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsService.java
@@ -1,0 +1,20 @@
+package com.uket.domain.terms.service;
+
+import com.uket.domain.terms.entity.Terms;
+import com.uket.domain.terms.repository.TermsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+
+    @Transactional(readOnly = true)
+    public List<Terms> findAllActive() {
+        return termsRepository.findAllByIsActiveTrue();
+    }
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsSignService.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsSignService.java
@@ -1,0 +1,24 @@
+package com.uket.domain.terms.service;
+
+import com.uket.domain.terms.entity.TermsSign;
+import com.uket.domain.terms.repository.TermsSignRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermsSignService {
+
+    private final TermsSignRepository termsSignRepository;
+
+    @Transactional(readOnly = true)
+    public Map<Long, Boolean> getTermsSignMap(Long userId, List<Long> termsIds){
+
+        return termsSignRepository.findLatestByUserIdAndTermsIds(userId, termsIds).stream()
+                .collect(Collectors.toMap(TermsSign::getTermsId, TermsSign::getIsAgreed));
+    }
+}

--- a/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsSignService.java
+++ b/domain/terms-domain/src/main/java/com/uket/domain/terms/service/TermsSignService.java
@@ -21,4 +21,9 @@ public class TermsSignService {
         return termsSignRepository.findLatestByUserIdAndTermsIds(userId, termsIds).stream()
                 .collect(Collectors.toMap(TermsSign::getTermsId, TermsSign::getIsAgreed));
     }
+
+    @Transactional
+    public List<TermsSign> saveAll(List<TermsSign> termsSigns){
+        return termsSignRepository.saveAll(termsSigns);
+    }
 }


### PR DESCRIPTION
# 📌 개요
- 약관 조회 API 추가했습니다.

# 💻 작업사항
- [x] 약관 관련 도메인 추가
- [x] 약관 조회 API 추가

# ❌ 주의사항
- 가장 최신의 약관 및 약관에 대한 동의 정보를 조회합니다.
- `Terms`: 약관 정보
- `TermsSign`: 약관 동의 목록
- `Document`: 문서 정보
  - 사용자의 동의 시점에 어떤 문서를 확인했는지가 중요하기 때문에 Terms와 Document를 분리해서 Document에서 버전을 관리합니다.

# 💡 코드 리뷰 요청사항
- N/A
