### PR TITLE
[SVR-67] 질의응답 response dto 수정

### DIFF
--- a/domain/form-domain/src/main/java/com/uket/domain/form/dto/FormDto.java
+++ b/domain/form-domain/src/main/java/com/uket/domain/form/dto/FormDto.java
@@ -7,8 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record FormDto(
-        Long id,
-        Long surveyId,
+        Long formId,
         FormType formType,
         List<OptionDto> options,
         String question,
@@ -16,8 +15,7 @@ public record FormDto(
 ) {
     public static FormDto from(Form form, List<OptionDto> options) {
         return FormDto.builder()
-                .id(form.getId())
-                .surveyId(form.getSurvey().getId())
+                .formId(form.getId())
                 .formType(form.getFormType())
                 .options(options)
                 .question(form.getQuestion())

--- a/domain/form-domain/src/main/java/com/uket/domain/form/dto/OptionDto.java
+++ b/domain/form-domain/src/main/java/com/uket/domain/form/dto/OptionDto.java
@@ -5,14 +5,12 @@ import lombok.Builder;
 
 @Builder
 public record OptionDto(
-        Long id,
-        Long formId,
+        Long optionId,
         String value
 ) {
     public static OptionDto from(Options option) {
         return OptionDto.builder()
-                .id(option.getId())
-                .formId(option.getForm().getId())
+                .optionId(option.getId())
                 .value(option.getValue())
                 .build();
     }


### PR DESCRIPTION
# 📌 개요
- 질의응답 api의 response dto에서 중복으로 보내는 내용을 삭제했습니다.

# 💻 작업사항
- 

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- N/A
