### PR TITLE
[SVR-68] 약관 동의 API 에러 응답 문서화

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/TermsApi.java
@@ -4,9 +4,13 @@ import com.uket.app.ticket.api.dto.request.TermsAgreementRequest;
 import com.uket.app.ticket.api.dto.response.ListResponse;
 import com.uket.app.ticket.api.dto.response.TermsAgreementResponse;
 import com.uket.app.ticket.api.dto.response.TermsResponse;
+import com.uket.core.dto.response.ErrorResponse;
 import com.uket.domain.auth.config.userid.LoginUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +37,24 @@ public interface TermsApi {
 
     @PostMapping("/api/v1/terms/agreement")
     @Operation(summary = "약관 동의 API", description = "회원가입 시 약관 동의를 할 수 있습니다.")
+    @ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(name = "TE0001", description = "약관 id에 해당하는 약관을 찾을 수 없습니다.",
+                            value = """
+                                    {"code": "TE0001", "message": "약관을 찾을 수 없습니다."}
+                                    """
+                    )
+            }, schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(
+            mediaType = "application/json",
+            examples = {
+                    @ExampleObject(name = "TE0002", description = "필수 문서에 대해 동의가 되지 않은 경우 발생합니다.",
+                            value = """
+                                    {"code": "TE0002", "message": "필수 문서는 동의가 필수입니다."}
+                                    """
+                    )
+            }, schema = @Schema(implementation = ErrorResponse.class)))
     ResponseEntity<ListResponse<TermsAgreementResponse>> agreeTerms(
             @LoginUserId
             @Parameter(hidden = true)


### PR DESCRIPTION
# 📌 개요
- 약관 동의 API 에러 응답 문서화
- 약관 조회에 대해 처리한 에러는 따로 없기에 동의 API에만 문서화를 진행했습니다.

# 💻 작업사항
- 약관 동의 API 에러 응답 문서화

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- N/A
