### PR TITLE
fix : [SVR-74] 예매 목록 조회 시 예외처리 수정

### DIFF
--- a/domain/form-domain/src/main/java/com/uket/domain/form/dto/AnswerDto.java
+++ b/domain/form-domain/src/main/java/com/uket/domain/form/dto/AnswerDto.java
@@ -19,5 +19,5 @@ public record AnswerDto(
                 .build();
     }
 
-    public static AnswerDto noAnswerDto = new AnswerDto(-1L, -1L, -1L, "");
+    public static AnswerDto noAnswerDto = new AnswerDto(-1L, -1L, -1L, "미응답");
 }

--- a/domain/form-domain/src/main/java/com/uket/domain/form/service/FormService.java
+++ b/domain/form-domain/src/main/java/com/uket/domain/form/service/FormService.java
@@ -44,10 +44,28 @@ public class FormService {
 
     public AnswerDto findAnswerByFormIdAndUserId(Long formId, Long userId, boolean isNecessary) {
         Answer answer = answerRepository.findAnswerByFormIdAndUserId(formId, userId);
+        /*
+        기존 데이터
+        - 필수 응답 여부와 관계 없이, 응답 데이터가 아예 없거나, 응답 내용이 ""일 수 있음
+
+        새로운 데이터
+        - 필수 응답인 경우, 응답 데이터가 무조건 존재하고 내용도 제대로 되어있음
+        - 필수 응답이 아닌 경우, 응답 데이터는 무조건 존재하지만 응답 내용이 "응답하지 않았습니다"일 수 있음
+
+        1. 응답 데이터가 존재하는가?
+        2. 응답 데이터가 존재는 한다면, 응답 내용이 잘못되어 있는가?
+         */
         if(answer == null)
-            throw new FormException(ErrorCode.NOT_FOUND_RESPONSE);
-        if(isNecessary && answer.getResponse().isEmpty())
-            throw new FormException(ErrorCode.NOT_FOUND_NECESSARY_RESPONSE);
+            return AnswerDto.noAnswerDto;
+        if(answer.getResponse().isEmpty() || answer.getResponse().equals("응답하지 않았습니다"))
+            return AnswerDto.noAnswerDto;
+
+        // TODO : 기존 데이터를 싹 날려버린 이후에는 새로운 데이터가 갖춰야할 조건에 대한 예외처리로 수정 필요 ex.하단 주석
+        // if(answer == null)
+        //     throw new FormException(ErrorCode.UNKNOWN_SERVER_ERROR);
+        // if(isNecessary && answer.getResponse().equals("응답하지 않았습니다"))
+        //     throw new FormException(ErrorCode.UNKNOWN_SERVER_ERROR);
+
         return AnswerDto.from(answer);
     }
 


### PR DESCRIPTION
# 📌 개요
- 기존 질의응답 도메인이 추가되기 이전 데이터는 모두 예외를 발생시키는데, 차후 데이터를 전부 삭제하고 처음부터 구성하기 전까지는 throw 대신 default 값으로 메워줄 수 있도록 수정했습니다.
- 새롭게 추가되는 데이터들은, 입력 부분의 validation을 통해서 무결한 데이터로 추가될 예정이라, throw 부분이 없어도 당분간은 큰 문제가 없을 것 같습니다.

# 💻 작업사항
- 기존 예외 발생 시 throw하던 것에서 default 값을 가진 AnswerDto를 리턴하도록 수정

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
