### PR TITLE
[SVR-81] 공연 목록, 정보, 예매 화면에서 축제명도 전달하도록 수정

### DIFF
--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/controller/impl/EventController.java
@@ -36,12 +36,15 @@ public class EventController implements EventApi {
     @Override
     public ResponseEntity<ShowResponse> getShows(Long userId, Long eventId) {
 
+        Events event = eventService.findById(eventId);
+        String eventName = event.getName();
+
         String universityName = eventService.findUniversityNameByEventId(eventId);
         ReservationUserType reservationUserType = eventService.getReservationUserTypeByUniversityName(userId, universityName);
 
         List<ShowDto> shows = showService.findByEventId(eventId);
 
-        ShowResponse response = ShowResponse.of(reservationUserType, universityName, shows);
+        ShowResponse response = ShowResponse.of(reservationUserType, universityName, eventName, shows);
         return ResponseEntity.ok(response);
     }
 

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ActiveUniversitiesResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ActiveUniversitiesResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 public record ActiveUniversitiesResponse(
         Long id,
         String name,
+        String eventName,
         String logoUrl,
         ZonedDateTime startDateTime
 ){}

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ShowResponse.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/dto/response/ShowResponse.java
@@ -7,10 +7,11 @@ import java.util.List;
 public record ShowResponse(
         String reservationUserType,
         String universityName,
+        String eventName,
         List<ShowDto> shows
 ) {
 
-    public static ShowResponse of(ReservationUserType reservationUserType, String university, List<ShowDto> shows) {
-        return new ShowResponse(reservationUserType.getValue(), university, shows);
+    public static ShowResponse of(ReservationUserType reservationUserType, String university, String event, List<ShowDto> shows) {
+        return new ShowResponse(reservationUserType.getValue(), university, event, shows);
     }
 }

--- a/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
+++ b/application/ticket-app-api/src/main/java/com/uket/app/ticket/api/util/S3ImageUrlConverter.java
@@ -53,6 +53,7 @@ public class S3ImageUrlConverter {
                     return ActiveUniversitiesResponse.builder()
                             .id(universityDto.id())
                             .name(universityDto.name())
+                            .eventName(currentEvent.getName())
                             .logoUrl(logoUrl)
                             .startDateTime(firstShowStartDateTime.atZone(ZoneId.of("Asia/Seoul")))
                             .build();


### PR DESCRIPTION
# 📌 개요
- 기존 공연 선택, 공연 정보, 예매 화면에서 대학명을 표시하고 있었는데, 이를 축제명으로 변경하기 위해서 API 응답에 축제명을 추가했습니다.

# 💻 작업사항
- /api/v1/universities
공연 선택 화면(=대학 목록 화면)에서, 축제명을 띄울 수 있도록 ActiveUniversitiesResponse에 축제명 필드를 추가하고 S3ImageUrlConverter에서 추가해줬습니다.
- /api/v1/universities/{id}/event
공연 정보 화면에서는 이미 대학명이 아닌 축제명을 넘기고 있었으므로 수정내역이 없습니다.
- /api/v1/events/{id}/shows
예매 화면 중(Show, Reservation, Survey) 대학명을 넘기고 있던 부분은 Show 뿐이어서 ShowResponse에 축제명 필드를 추가하고, Controller에서 eventService를 호출해 축제명을 넘겨줬습니다.

# ❌ 주의사항
- 수정 내역이 적지만, 제가 수정하면 보통 한번씩 터지는 것 같으므로 😅 한번만 확인부탁드립니다.

# 💡 코드 리뷰 요청사항
- 
