### PR TITLE
[SVR-82] 예매 목록 관리 화면에서 결과를 주문 일시에 대해 내림차순으로 정렬

### DIFF
--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -32,6 +32,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -75,7 +77,7 @@ public class TicketController implements TicketApi {
         // 4. ticket 소유자마다, 해당 event에 대한 answer list get
         // 5. 3, 4번의 내용을 합치기
 
-        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Direction.DESC, "createdAt"));
         Page<CheckTicketDto> ticketsPage = ticketService.searchAllTickets(pageRequest);
 
         List<CheckTicketDto> tickets = ticketsPage.getContent();
@@ -101,7 +103,7 @@ public class TicketController implements TicketApi {
             int page,
             int size
     ) {
-        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        PageRequest pageRequest = PageRequest.of(page - 1, size, Sort.by(Direction.DESC, "createdAt"));
 
         Page<CheckTicketDto> ticketsPage = ticketSearchers.stream()
                 .filter(ticketSearcher -> ticketSearcher.isSupport(searchType))

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/TicketController.java
@@ -108,7 +108,7 @@ public class TicketController implements TicketApi {
         Page<CheckTicketDto> ticketsPage = ticketSearchers.stream()
                 .filter(ticketSearcher -> ticketSearcher.isSupport(searchType))
                 .findFirst().orElseThrow(() -> new AdminException(ErrorCode.INVALID_SEARCH_TYPE))
-                .search(searchRequest, PageRequest.of(page - 1, size));
+                .search(searchRequest, pageRequest);
 
         List<CheckTicketDto> tickets = ticketsPage.getContent();
         List<CheckTicketingDto> ticketingDtos = ticketSearchService.searchAllUserAnswersFromTickets(tickets);


### PR DESCRIPTION
# 📌 개요
- 예매 목록 관리 화면에서 예매 목록을 주문 일시에 대한 내림차순(최신순)으로 정렬했습니다.

# 💻 작업사항
- 전체 목록을 불러올 때, 검색 했을 때 모두 createdAt에 대한 내림차순 요청을 PageRequest를 통해 전달했습니다.

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
