### PR TITLE
[UKET-22] 어드민 계정 권한 구분

### DIFF
--- a/migration/src/main/java/com/uket/app/domain/user/Admin.java
+++ b/migration/src/main/java/com/uket/app/domain/user/Admin.java
@@ -1,0 +1,35 @@
+package com.uket.app.domain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private AdminRole role;
+
+    private String email;
+    private String password;
+    private String name;
+    private Boolean isRegistered;
+}

--- a/migration/src/main/java/com/uket/app/domain/user/AdminRole.java
+++ b/migration/src/main/java/com/uket/app/domain/user/AdminRole.java
@@ -1,0 +1,5 @@
+package com.uket.app.domain.user;
+
+public enum AdminRole {
+    ADMINISTRATOR, MEMBER
+}


### PR DESCRIPTION
# 📌 개요
- 어드민 계정 권한 구분을 위해 AdminRole Enum 클래스 추가

# 💻 작업사항
- migration 모듈에 기존 Admin 엔티티 추가
- migration 모듈에 AdminRole Enum 추가

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 결정이 필요하면서, 로그인/회원가입 쪽 PR과 관련이 있는 내용이 있는 것 같습니다.
현재 사용자에 대한 엔티티가 Users와 Admin 2개로 나뉘어 있는데, Users가 UserRole이라는 Enum 값을 가지고 있는 상태입니다.<br>
코드를 확인해보니 UserRole은 JWT 관련 작업에만 사용되는 것으로 보이긴 합니다.
(= 토큰을 생성할 때 ROLE_ADMIN을 넣고 검증할 때에는 토큰 내용이 ROLE_ADMIN인가를 확인)<br>
어쨋든 Users와 Admin을 합칠 지 말 지 정도는 정해야하지 않나 싶은 생각이 들어서 코드 리뷰 요청드립니다.
우선 현재는 합치지 않는다는 가정하에 코드를 작성해둔 상태이긴 한데, 
어차피 로그인/회원가입 쪽 PR 합쳐지면서 수정해야할 부분들이 생길 것이라고 생각하고 있습니다.