### PR TITLE
Admin 역할 구분 & 전체 Admin 조회 API 재작성

### DIFF
--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/MemberApi.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/MemberApi.java
@@ -1,0 +1,26 @@
+package com.uket.app.admin.api.controller;
+
+import com.uket.app.admin.api.dto.response.SearchAdminsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "어드민 사용자 관리 API", description = "어드민 사용자 관리 API")
+@RestController
+@RequestMapping("/admin/v1/member")
+@ApiResponse(responseCode = "200", description = "OK")
+public interface MemberApi {
+
+    @Operation(summary = "어드민 멤버 전체 조회", description = "어드민 전체 멤버 목록을 페이지별로 조회합니다. 페이지는 1부터 시작합니다.")
+    @GetMapping("/search/all")
+    ResponseEntity<SearchAdminsResponse> searchAllAdmins(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    );
+
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/MemberController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/MemberController.java
@@ -1,0 +1,28 @@
+package com.uket.app.admin.api.controller.impl;
+
+import com.uket.app.admin.api.controller.MemberApi;
+import com.uket.domain.auth.admin.dto.SearchAdminDto;
+import com.uket.app.admin.api.dto.response.SearchAdminsResponse;
+import com.uket.domain.auth.admin.service.AdminService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MemberController implements MemberApi {
+
+    private AdminService adminService;
+
+    @Override
+    public ResponseEntity<SearchAdminsResponse> searchAllAdmins(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        Page<SearchAdminDto> dtoPage = adminService.searchAllAdmins(pageRequest);
+        List<SearchAdminDto> dtoList = dtoPage.getContent();
+        return ResponseEntity.ok(SearchAdminsResponse.from(dtoList));
+    }
+
+}

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/MemberController.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/controller/impl/MemberController.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class MemberController implements MemberApi {
 
-    private AdminService adminService;
+    private final AdminService adminService;
 
     @Override
     public ResponseEntity<SearchAdminsResponse> searchAllAdmins(int page, int size) {

--- a/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/SearchAdminsResponse.java
+++ b/application/admin-app-api/src/main/java/com/uket/app/admin/api/dto/response/SearchAdminsResponse.java
@@ -1,0 +1,16 @@
+package com.uket.app.admin.api.dto.response;
+
+import com.uket.domain.auth.admin.dto.SearchAdminDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SearchAdminsResponse(
+        List<SearchAdminDto> memberList
+) {
+    public static SearchAdminsResponse from(List<SearchAdminDto> dtoList) {
+        return SearchAdminsResponse.builder()
+                .memberList(dtoList)
+                .build();
+    }
+}

--- a/domain/admin-auth-domain/build.gradle
+++ b/domain/admin-auth-domain/build.gradle
@@ -2,9 +2,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 
     implementation project(":domain:core-domain")
     implementation project(":domain:user-domain")
+    implementation project(":domain:university-domain")
     implementation project(":modules:jwt-provider")
 }
 

--- a/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/dto/SearchAdminDto.java
+++ b/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/dto/SearchAdminDto.java
@@ -1,0 +1,27 @@
+package com.uket.domain.auth.admin.dto;
+
+import com.uket.domain.auth.admin.entity.Admin;
+import com.uket.domain.auth.admin.entity.AdminRole;
+import com.uket.domain.university.entity.University;
+import lombok.Builder;
+
+@Builder
+public record SearchAdminDto(
+        Long adminId,
+        AdminRole role,
+        String universityName,
+        String email,
+        String name
+) {
+    public static SearchAdminDto from(Admin admin) {
+        University university = admin.getUniversity();
+        return SearchAdminDto.builder()
+                .adminId(admin.getId())
+                .role(admin.getRole())
+                .universityName(university.getName())
+                .email(admin.getEmail())
+                .name(admin.getName())
+                .build();
+    }
+
+}

--- a/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/entity/Admin.java
+++ b/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/entity/Admin.java
@@ -1,10 +1,15 @@
 package com.uket.domain.auth.admin.entity;
 
+import com.uket.domain.university.entity.University;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +27,13 @@ public class Admin {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "admin_id")
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "university_id")
+    private University university;
+
+    @Enumerated(EnumType.STRING)
+    private AdminRole role;
 
     private String email;
     private String password;

--- a/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/entity/AdminRole.java
+++ b/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/entity/AdminRole.java
@@ -1,0 +1,5 @@
+package com.uket.domain.auth.admin.entity;
+
+public enum AdminRole {
+    ADMINISTRATOR, MEMBER
+}

--- a/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/service/AdminService.java
+++ b/domain/admin-auth-domain/src/main/java/com/uket/domain/auth/admin/service/AdminService.java
@@ -1,10 +1,13 @@
 package com.uket.domain.auth.admin.service;
 
 import com.uket.core.exception.ErrorCode;
+import com.uket.domain.auth.admin.dto.SearchAdminDto;
 import com.uket.domain.auth.admin.entity.Admin;
 import com.uket.domain.auth.admin.exception.AuthException;
 import com.uket.domain.auth.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,5 +38,11 @@ public class AdminService {
                 .build();
 
         return adminRepository.save(admin);
+    }
+
+    @Transactional
+    public Page<SearchAdminDto> searchAllAdmins(Pageable pageable) {
+        Page<Admin> admins = adminRepository.findAll(pageable);
+        return admins.map(SearchAdminDto::from);
     }
 }

--- a/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminRepositoryTest.java
+++ b/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.uket.domain.auth.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.uket.domain.auth.admin.entity.Admin;
+import com.uket.domain.auth.admin.repository.AdminRepository;
+import com.uket.domain.university.entity.University;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@DataJpaTest
+public class AdminRepositoryTest {
+    @Autowired private AdminRepository adminRepository;
+    @Autowired private EntityManager em;
+
+    @Test
+    @DisplayName("어드민 findAll(Pageable) 테스트")
+    void testFindAllAdmin() {
+        // given
+        University university = University.builder()
+                .name("universityA")
+                .build();
+        em.persist(university);
+        Admin admin1 = Admin.builder()
+                .university(university)
+                .build();
+        Admin admin2 = Admin.builder()
+                .university(university)
+                .build();
+
+        adminRepository.save(admin1);
+        adminRepository.save(admin2);
+
+        // when
+        Page<Admin> findAdmins = adminRepository.findAll(PageRequest.of(0, 2));
+
+        // then
+        List<Admin> admins = findAdmins.getContent();
+        assertThat(admins.size()).isEqualTo(2);
+        assertThat(admins.stream().anyMatch(a -> a.getId() == 1L)).isEqualTo(true);
+        assertThat(admins.stream().anyMatch(a -> a.getId() == 2L)).isEqualTo(true);
+        assertThat(admins.get(0).getUniversity().getName()).isEqualTo("universityA");
+        System.out.println("admins = " + admins);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EntityScan(basePackages = "com.uket")
+    @EnableJpaRepositories(basePackages = "com.uket")
+    static class RepositoryConfigure {
+    }
+}

--- a/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminRepositoryTest.java
+++ b/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminRepositoryTest.java
@@ -55,8 +55,8 @@ public class AdminRepositoryTest {
 
     @Configuration
     @EnableAutoConfiguration
-    @EntityScan(basePackages = "com.uket")
-    @EnableJpaRepositories(basePackages = "com.uket")
+    @EntityScan(basePackages = { "com.uket.domain.auth.admin", "com.uket.domain.university" })
+    @EnableJpaRepositories(basePackages = "com.uket.domain.auth.admin")
     static class RepositoryConfigure {
     }
 }

--- a/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminServiceTest.java
+++ b/domain/admin-auth-domain/src/test/java/com/uket/domain/auth/admin/service/AdminServiceTest.java
@@ -1,0 +1,66 @@
+package com.uket.domain.auth.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.uket.domain.auth.admin.dto.SearchAdminDto;
+import com.uket.domain.auth.admin.entity.Admin;
+import com.uket.domain.auth.admin.repository.AdminRepository;
+import com.uket.domain.university.entity.University;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Test
+    @DisplayName("어드민 전체 조회 테스트")
+    void testSearchAdmin() {
+        // given
+        University university = University.builder()
+                .id(1L)
+                .name("universityA")
+                .build();
+        Admin admin1 = Admin.builder()
+                .id(1L)
+                .university(university)
+                .build();
+        Admin admin2 = Admin.builder()
+                .id(2L)
+                .university(university)
+                .build();
+        Admin admin3 = Admin.builder()
+                .id(3L)
+                .university(university)
+                .build();
+
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        when(adminRepository.findAll(pageRequest)).thenReturn(
+                new PageImpl<>(List.of(admin1, admin2))
+        );
+
+        // when
+        Page<SearchAdminDto> searchAdminDtos = adminService.searchAllAdmins(pageRequest);
+
+        // then
+        List<SearchAdminDto> adminDtos = searchAdminDtos.getContent();
+        assertThat(adminDtos.size()).isEqualTo(2);
+        assertThat(adminDtos.get(0).universityName()).isEqualTo("universityA");
+        System.out.println("adminDtos = " + adminDtos);
+    }
+
+}

--- a/domain/admin-auth-domain/src/test/resources/application.yml
+++ b/domain/admin-auth-domain/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
# 📌 개요
- migration 모듈에서의 작업내용을 기존 모듈(admin-auth, admin-api)에 적용하고, 테스트 진행했습니다.

# 💻 작업사항
- AdminRole 추가 및 Admin에 추가
- Admin에 University와의 관계 추가
- Admin 조회 API 추가(MemberApi, MemberController, MemberService, MemberRepository)

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
